### PR TITLE
Pull Request: Bug Fix - Support for ContentEditable Text Selection in TranslatorPopup

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sctools",
   "description": "manifest.json description",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Juan Pablo Leon Maya co.coffeecode@gmail.com",
   "type": "module",
   "scripts": {

--- a/src/config/utils/__test__/selectTextInContentEditable.test.ts
+++ b/src/config/utils/__test__/selectTextInContentEditable.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { selectTextInContentEditable } from "../selectTextInContentEditable";
+
+// Mock DOM APIs
+const mockRange = {
+  selectNodeContents: vi.fn(),
+};
+
+const mockSelection = {
+  removeAllRanges: vi.fn(),
+  addRange: vi.fn(),
+};
+
+Object.defineProperty(document, 'createRange', {
+  value: vi.fn(() => mockRange),
+  writable: true,
+});
+
+Object.defineProperty(window, 'getSelection', {
+  value: vi.fn(() => mockSelection),
+  writable: true,
+});
+
+describe('selectTextInContentEditable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create a range and select node contents', () => {
+    const mockElement = document.createElement('div');
+    mockElement.contentEditable = 'true';
+    mockElement.textContent = 'Test content';
+
+    selectTextInContentEditable(mockElement);
+
+    expect(document.createRange).toHaveBeenCalled();
+    expect(mockRange.selectNodeContents).toHaveBeenCalledWith(mockElement);
+  });
+
+  it('should clear existing selection and add new range', () => {
+    const mockElement = document.createElement('div');
+    mockElement.contentEditable = 'true';
+
+    selectTextInContentEditable(mockElement);
+
+    expect(window.getSelection).toHaveBeenCalled();
+    expect(mockSelection.removeAllRanges).toHaveBeenCalled();
+    expect(mockSelection.addRange).toHaveBeenCalledWith(mockRange);
+  });
+
+  it('should handle null selection gracefully', () => {
+    const mockElement = document.createElement('div');
+    
+    // Mock getSelection to return null
+    vi.mocked(window.getSelection).mockReturnValue(null);
+
+    expect(() => {
+      selectTextInContentEditable(mockElement);
+    }).not.toThrow();
+
+    expect(document.createRange).toHaveBeenCalled();
+    expect(mockRange.selectNodeContents).toHaveBeenCalledWith(mockElement);
+  });
+
+  it('should work with different HTML elements', () => {
+    const elements = [
+      document.createElement('div'),
+      document.createElement('span'),
+      document.createElement('p'),
+      document.createElement('textarea'),
+    ];
+
+    elements.forEach((element) => {
+      selectTextInContentEditable(element);
+      expect(mockRange.selectNodeContents).toHaveBeenCalledWith(element);
+    });
+
+    expect(document.createRange).toHaveBeenCalledTimes(elements.length);
+  });
+
+  it('should handle elements with complex content', () => {
+    const mockElement = document.createElement('div');
+    mockElement.innerHTML = '<span>Hello</span> <strong>World</strong>';
+
+    selectTextInContentEditable(mockElement);
+
+    expect(document.createRange).toHaveBeenCalled();
+    expect(mockRange.selectNodeContents).toHaveBeenCalledWith(mockElement);
+    expect(mockSelection.removeAllRanges).toHaveBeenCalled();
+    expect(mockSelection.addRange).toHaveBeenCalledWith(mockRange);
+  });
+
+  it('should handle empty elements', () => {
+    const mockElement = document.createElement('div');
+    // Element with no content
+
+    selectTextInContentEditable(mockElement);
+
+    expect(document.createRange).toHaveBeenCalled();
+    expect(mockRange.selectNodeContents).toHaveBeenCalledWith(mockElement);
+    expect(mockSelection.removeAllRanges).toHaveBeenCalled();
+    expect(mockSelection.addRange).toHaveBeenCalledWith(mockRange);
+  });
+
+  it('should call methods in correct order', () => {
+    const mockElement = document.createElement('div');
+    const callOrder: string[] = [];
+
+    vi.mocked(document.createRange).mockImplementation(() => {
+      callOrder.push('createRange');
+      return {
+        selectNodeContents: vi.fn(() => {
+          callOrder.push('selectNodeContents');
+        }),
+      } as any;
+    });
+
+    vi.mocked(window.getSelection).mockImplementation(() => {
+      callOrder.push('getSelection');
+      return {
+        removeAllRanges: vi.fn(() => {
+          callOrder.push('removeAllRanges');
+        }),
+        addRange: vi.fn(() => {
+          callOrder.push('addRange');
+        }),
+      } as any;
+    });
+
+    selectTextInContentEditable(mockElement);
+
+    expect(callOrder).toEqual([
+      'createRange',
+      'selectNodeContents',
+      'getSelection',
+      'removeAllRanges',
+      'addRange',
+    ]);
+  });
+});

--- a/src/config/utils/selectTextInContentEditable.ts
+++ b/src/config/utils/selectTextInContentEditable.ts
@@ -1,0 +1,7 @@
+export const selectTextInContentEditable = (element: HTMLElement) => {
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+};

--- a/src/presentation/components/InputLocalTranslator/TranslatorPopup.tsx
+++ b/src/presentation/components/InputLocalTranslator/TranslatorPopup.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useState, useEffect } from "react";
 import { GLOBAL_STRINGS } from "~@/config/utils/globalStrings";
+import { selectTextInContentEditable } from "~@/config/utils/selectTextInContentEditable";
 import { useLocalTranslatorTargetLanguage } from "~@/presentation/hooks/useLocalTranslatorTargetLanguage/useLocalTranslatorTargetLanguage";
 
 interface PopupPosition {
@@ -48,7 +49,8 @@ export const TranslatorPopup = forwardRef<HTMLDivElement, TranslatorPopupProps>(
       const handleKeyPress = (event: KeyboardEvent) => {
         if (event.ctrlKey && event.key.toLowerCase() === "q") {
           event.preventDefault();
-          (event.target as HTMLInputElement)?.select();
+          const target = event.target as HTMLInputElement;
+          target.select ? target.select() : selectTextInContentEditable(target);
           insertTranslate();
         }
       };


### PR DESCRIPTION
# Pull Request: Bug Fix - Support for ContentEditable Text Selection in TranslatorPopup

## Description
This pull request addresses a bug in the TranslatorPopup component where text selection in contenteditable elements was not properly handled. The changes introduce support for selecting and translating text within contenteditable fields, enhancing the user experience for translation functionality. Additionally, new tests have been added to validate the behavior of text selection in these elements.

## Changes
- **Feature**:
  - Added support for contenteditable text selection in the `TranslatorPopup` component (`feat(TranslatorPopup): add support for contenteditable text selection`).
- **Testing**:
  - Introduced new tests to verify text selection functionality in contenteditable elements (`test(translator): add tests for content editable text selection`).


## Testing Instructions
1. Install the extension and go to chaturbate.com in a streaming room.
2. Type something in the chat box and press the translation shortcut.
3. Check if the text in the box has been translated.

## Additional Notes
- The changes are isolated to the `TranslatorPopup` component and its tests, with no impact on other modules.
- No new dependencies were introduced.
- This fix is critical for the `release/1.1.1` to ensure a seamless user experience in contenteditable translation scenarios.