### PR TITLE
🔖 release: 1.4.2

### DIFF
--- a/docs/changelog/1.4.2/CHANGELOG.md
+++ b/docs/changelog/1.4.2/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [1.4.2] - 2026-04-12
+
+### Added
+
+- Add help link in subtitle display for OBS subtitle freeze issue, linking to documentation on the browser window occlusion fix (5671fd0)
+
+### Changed
+
+- Bump version to 1.4.2 (d89d77c)
+
+[1.4.2]: https://keepachangelog.com/en/1.1.0/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "redna-models",
   "description": "manifest.json description",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.4.2",
   "author": "Juan Pablo Leon Maya co.coffeecode@gmail.com",
   "type": "module",
   "scripts": {

--- a/src/presentation/components/SubtitleDisplay/HelpLink.tsx
+++ b/src/presentation/components/SubtitleDisplay/HelpLink.tsx
@@ -1,0 +1,23 @@
+import { CircleHelp } from "lucide-react";
+import { cn } from "~@/presentation/lib/utils";
+
+interface HelpLinkProps {
+  href: string;
+  label: string;
+  className?: string;
+}
+
+export const HelpLink = ({ href, label, className }: HelpLinkProps) => (
+  <a
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    className={cn(
+      "flex items-center gap-1.5 rounded-md bg-black/30 px-2 py-1 text-xs text-white no-underline opacity-30 transition-opacity hover:opacity-100",
+      className
+    )}
+  >
+    <CircleHelp className="size-4 shrink-0" />
+    {label}
+  </a>
+);

--- a/src/presentation/components/SubtitleDisplay/SubtitleDisplay.tsx
+++ b/src/presentation/components/SubtitleDisplay/SubtitleDisplay.tsx
@@ -8,6 +8,8 @@ import { useSubtitleBgColor } from "~@/presentation/hooks/useSubtitleBgColor/use
 import { useSubtitleFontColor } from "~@/presentation/hooks/useSubtitleFontColor/useSubtitleFontColor";
 import { useSubtitleFontSize } from "~@/presentation/hooks/useSubtitleFontSize/useSubtitleFontSize";
 import { SubtitleControls } from "./controls/SubtitleControls";
+import { SUBTITLE_STRINGS } from "./constants";
+import { HelpLink } from "./HelpLink";
 import { SubtitleLine } from "./SubtitleLine";
 import { SubtitleLoadingIndicator } from "./SubtitleLoadingIndicator";
 import { TranslatorDownloadPrompt } from "./TranslatorDownloadPrompt";
@@ -123,6 +125,11 @@ export const SubtitleDisplay = () => {
         bgColor={bgColor}
         onBgColorChange={handleBgColorChange}
         onClear={clearLines}
+      />
+      <HelpLink
+        href={SUBTITLE_STRINGS.FREEZE_HELP_URL}
+        label={SUBTITLE_STRINGS.FREEZE_HELP_LABEL}
+        className="absolute top-1 left-1 z-50"
       />
       <div className="flex flex-col items-start justify-center gap-2 py-4">
         {displayLines.map((line, index) => {

--- a/src/presentation/components/SubtitleDisplay/constants.ts
+++ b/src/presentation/components/SubtitleDisplay/constants.ts
@@ -1,0 +1,5 @@
+export const SUBTITLE_STRINGS = {
+  FREEZE_HELP_LABEL: "¿Se congelan los subtítulos en OBS?",
+  FREEZE_HELP_URL:
+    "https://estrellaswebcam.com/guides/extensiones/redna-models/funcionalidades/traductor-voz/#los-subt%C3%ADtulos-se-congelan-cuando-otra-ventana-cubre-chrome",
+} as const;

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -5,6 +5,7 @@ import tailwindcss from "@tailwindcss/vite";
 export default defineConfig({
   manifest: {
     permissions: ["activeTab", "tabs", "storage", "scripting"],
+    host_permissions: ["https://www.estrellaswebcam.com/*"],
     name: "Redna Models",
     description:
       "Incorporamos herramientas para mejorar la experiencia de trabajo de los modelos de EW.",


### PR DESCRIPTION
## Release 1.4.2

### Overview
This release adds a contextual help link in the subtitle display screen for users experiencing frozen subtitles in OBS. The link points to documentation explaining the browser window occlusion issue and how to fix it by launching Chrome with a specific flag.

### Changes

### Added

- Add help link in subtitle display for OBS subtitle freeze issue, linking to documentation on the browser window occlusion fix (5671fd0)

### Changed

- Bump version to 1.4.2 (d89d77c)

### Checklist
- [x] CHANGELOG reviewed
- [x] Tests passing
- [x] No breaking changes undocumented