### PR TITLE
🔖 release: 1.5.0

### DIFF
--- a/src/presentation/hooks/useLocalTranslatorTargetLanguage/useLocalTranslatorTargetLanguage.tsx
+++ b/src/presentation/hooks/useLocalTranslatorTargetLanguage/useLocalTranslatorTargetLanguage.tsx
@@ -1,58 +1,8 @@
-/**
- * Custom hook for interacting with `localStorage`.
- * This hook provides a interface to manage the local translator target language state.
- * in the browser's local storage, with fallback support for Chrome extension storage.
- *
- * @module hooks/useLocalTranslatorTargetLanguage
- */
-
-import { storage } from "#imports";
-
 import { GLOBAL_STRINGS } from "~@/config/utils/globalStrings";
 
-type SetValue = (value: string) => Promise<void>;
-type GetValue = () => Promise<string>;
-type WatchItem = (callback: (value: string) => void) => void;
+import { createStorageHook } from "../useStorageItem/useStorageItem";
 
-interface IUseLocalTranslatorTargetLanguage {
-  setItem: SetValue;
-  getItem: GetValue;
-  watchItem: WatchItem;
-}
-
-const localTranslatorTargetLanguage = storage.defineItem<string>(
-  `local:${GLOBAL_STRINGS.STORAGE_KEYS.LOCAL_TRANSLATOR_TARGET_LANGUAGE}`,
-  {
-    fallback: "en",
-  },
+export const useLocalTranslatorTargetLanguage = createStorageHook<string>(
+  GLOBAL_STRINGS.STORAGE_KEYS.LOCAL_TRANSLATOR_TARGET_LANGUAGE,
+  "en",
 );
-
-export const useLocalTranslatorTargetLanguage =
-  (): IUseLocalTranslatorTargetLanguage => {
-    return {
-      /**
-       * Sets the target language.
-       * @param {string} value - The target language to set.
-       * @returns {Promise<void>}
-       */
-      setItem: async (value: string): Promise<void> => {
-        await localTranslatorTargetLanguage.setValue(value);
-      },
-      /**
-       * Gets the current target language.
-       * @returns {Promise<string>} - The stored target language.
-       */
-      getItem: async (): Promise<string> => {
-        return await localTranslatorTargetLanguage.getValue();
-      },
-      /**
-       * Watches for changes to the target language.
-       * @param {function} callback - The callback function to be invoked when the target language changes.
-       */
-      watchItem: async (callback: (value: string) => void) => {
-        await localTranslatorTargetLanguage.watch((newValue) => {
-          callback(newValue);
-        });
-      },
-    };
-  };

--- a/src/presentation/hooks/useQuickMenuIsActive/useQuickMenuIsActive.ts
+++ b/src/presentation/hooks/useQuickMenuIsActive/useQuickMenuIsActive.ts
@@ -1,62 +1,8 @@
-/**
- * Custom hook for interacting with `localStorage`.
- * This hook provides a interface to manage the quick menu active state.
- * in the browser's local storage, with fallback support for Chrome extension storage.
- *
- * @module hooks/useQuickMenuIsActive
- */
-
-import { storage } from "#imports";
-
 import { GLOBAL_STRINGS } from "~@/config/utils/globalStrings";
 
-type SetValue = (value: boolean) => Promise<void>;
-type GetValue = () => Promise<boolean>;
-type WatchItem = (callback: (value: boolean) => void) => void;
+import { createStorageHook } from "../useStorageItem/useStorageItem";
 
-interface IUseQuickMenuIsActive {
-  setItem: SetValue;
-  getItem: GetValue;
-  watchItem: WatchItem;
-}
-
-const quickMenuIsActive = storage.defineItem<boolean>(
-  `local:${GLOBAL_STRINGS.STORAGE_KEYS.QUICK_MENU_IS_ACTIVE}`,
-  {
-    fallback: true,
-  },
+export const useQuickMenuIsActive = createStorageHook<boolean>(
+  GLOBAL_STRINGS.STORAGE_KEYS.QUICK_MENU_IS_ACTIVE,
+  true,
 );
-
-/**
- * Custom hook for interacting with local storage for quick menu state.
- *
- * @returns {IUseQuickMenuIsActive} - An object containing storage methods for quick menu activate state.
- */
-export const useQuickMenuIsActive = (): IUseQuickMenuIsActive => {
-  return {
-    /**
-     * Sets the active state of the quick menu.
-     * @param {boolean} value - The state to set (true for active, false for inactive).
-     * @returns {Promise<void>}
-     */
-    setItem: async (value: boolean): Promise<void> => {
-      await quickMenuIsActive.setValue(value);
-    },
-    /**
-     * Gets the current active state of the quick menu.
-     * @returns {Promise<boolean>} - The stored state (true for active, false for inactive).
-     */
-    getItem: async (): Promise<boolean> => {
-      return await quickMenuIsActive.getValue();
-    },
-    /**
-     * Watches for changes to the quick menu active state.
-     * @param {function} callback - The callback function to be invoked when the state changes.
-     */
-    watchItem: async (callback: (value: boolean) => void) => {
-      await quickMenuIsActive.watch((newValue) => {
-        callback(newValue);
-      });
-    },
-  };
-};

--- a/src/presentation/hooks/useQuickMessagesStatus/useQuickMessagesStatus.ts
+++ b/src/presentation/hooks/useQuickMessagesStatus/useQuickMessagesStatus.ts
@@ -1,69 +1,8 @@
-import { storage } from "#imports";
-
 import { GLOBAL_STRINGS } from "~@/config/utils/globalStrings";
 
-/**
- * Type alias for setting the quick messages status value.
- */
-type SetValue = (value: boolean) => Promise<void>;
+import { createStorageHook } from "../useStorageItem/useStorageItem";
 
-/**
- * Type alias for getting the quick messages status value.
- */
-type GetValue = () => Promise<boolean>;
-
-/**
- * Type alias for watching changes in the quick messages status value.
- */
-type WatchItem = (callback: (value: boolean) => void) => void;
-
-/**
- * Interface for the useQuickMessagesStatus hook.
- */
-interface IUseQuickMessagesStatus {
-  /**
-   * Sets the quick messages status.
-   * @param value - The boolean value to set.
-   * @returns A promise that resolves when the value is set.
-   */
-  setItem: SetValue;
-  /**
-   * Gets the current quick messages status.
-   * @returns A promise that resolves to the current boolean value.
-   */
-  getItem: GetValue;
-  /**
-   * Watches for changes in the quick messages status.
-   * @param callback - The function to call when the value changes.
-   */
-  watchItem: WatchItem;
-}
-
-const quickMessagesStatus = storage.defineItem<boolean>(
-  `local:${GLOBAL_STRINGS.STORAGE_KEYS.QUICK_MESSAGES_IS_ACTIVE}`,
-  {
-    fallback: true,
-  },
+export const useQuickMessagesStatus = createStorageHook<boolean>(
+  GLOBAL_STRINGS.STORAGE_KEYS.QUICK_MESSAGES_IS_ACTIVE,
+  true,
 );
-
-/**
- * Hook to manage the quick messages active status.
- * Provides methods to set, get, and watch the status value in local storage.
- *
- * @returns {IUseQuickMessagesStatus} An object containing methods to interact with the quick messages status.
- */
-export const useQuickMessagesStatus = (): IUseQuickMessagesStatus => {
-  return {
-    setItem: async (value: boolean): Promise<void> => {
-      await quickMessagesStatus.setValue(value);
-    },
-    getItem: async (): Promise<boolean> => {
-      return await quickMessagesStatus.getValue();
-    },
-    watchItem: (callback: (value: boolean) => void) => {
-      quickMessagesStatus.watch((newValue) => {
-        callback(newValue);
-      });
-    },
-  };
-};

--- a/src/presentation/hooks/useSpeechToTranslateStatus/useSpeechToTranslateStatus.ts
+++ b/src/presentation/hooks/useSpeechToTranslateStatus/useSpeechToTranslateStatus.ts
@@ -1,41 +1,8 @@
-import { storage } from "#imports";
 import { GLOBAL_STRINGS } from "~@/config/utils/globalStrings";
 
-type SetValue = (value: boolean) => Promise<void>;
-type GetValue = () => Promise<boolean>;
-type WatchItem = (callback: (value: boolean) => void) => void;
+import { createStorageHook } from "../useStorageItem/useStorageItem";
 
-interface IUseSpeechToTranslateStatus {
-  setItem: SetValue;
-  getItem: GetValue;
-  watchItem: WatchItem;
-}
-
-const speechToTranslateStatus = storage.defineItem<boolean>(
-  `local:${GLOBAL_STRINGS.STORAGE_KEYS.SPEECH_TO_TRANSLATE_IS_ACTIVE}`,
-  {
-    fallback: false,
-  },
+export const useSpeechToTranslateStatus = createStorageHook<boolean>(
+  GLOBAL_STRINGS.STORAGE_KEYS.SPEECH_TO_TRANSLATE_IS_ACTIVE,
+  false,
 );
-
-/**
- * Hook to manage the speech-to-translate active status.
- * Provides methods to set, get, and watch the status value in local storage.
- *
- * @returns {IUseSpeechToTranslateStatus} Methods to interact with the speech-to-translate status.
- */
-export const useSpeechToTranslateStatus = (): IUseSpeechToTranslateStatus => {
-  return {
-    setItem: async (value: boolean): Promise<void> => {
-      await speechToTranslateStatus.setValue(value);
-    },
-    getItem: async (): Promise<boolean> => {
-      return await speechToTranslateStatus.getValue();
-    },
-    watchItem: (callback: (value: boolean) => void) => {
-      speechToTranslateStatus.watch((newValue) => {
-        callback(newValue);
-      });
-    },
-  };
-};

--- a/src/presentation/hooks/useSpeechToTranslateTabId/useSpeechToTranslateTabId.ts
+++ b/src/presentation/hooks/useSpeechToTranslateTabId/useSpeechToTranslateTabId.ts
@@ -1,41 +1,8 @@
-import { storage } from "#imports";
 import { GLOBAL_STRINGS } from "~@/config/utils/globalStrings";
 
-type SetValue = (value: number | null) => Promise<void>;
-type GetValue = () => Promise<number | null>;
-type WatchItem = (callback: (value: number | null) => void) => void;
+import { createStorageHook } from "../useStorageItem/useStorageItem";
 
-interface IUseSpeechToTranslateTabId {
-  setItem: SetValue;
-  getItem: GetValue;
-  watchItem: WatchItem;
-}
-
-const speechToTranslateTabId = storage.defineItem<number | null>(
-  `local:${GLOBAL_STRINGS.STORAGE_KEYS.SPEECH_TO_TRANSLATE_TAB_ID}`,
-  {
-    fallback: null,
-  },
+export const useSpeechToTranslateTabId = createStorageHook<number | null>(
+  GLOBAL_STRINGS.STORAGE_KEYS.SPEECH_TO_TRANSLATE_TAB_ID,
+  null,
 );
-
-/**
- * Hook to manage the tab ID of the subtitle display page.
- * Provides methods to set, get, and watch the tab ID value in local storage.
- *
- * @returns {IUseSpeechToTranslateTabId} Methods to interact with the subtitle tab ID.
- */
-export const useSpeechToTranslateTabId = (): IUseSpeechToTranslateTabId => {
-  return {
-    setItem: async (value: number | null): Promise<void> => {
-      await speechToTranslateTabId.setValue(value);
-    },
-    getItem: async (): Promise<number | null> => {
-      return await speechToTranslateTabId.getValue();
-    },
-    watchItem: (callback: (value: number | null) => void) => {
-      speechToTranslateTabId.watch((newValue) => {
-        callback(newValue);
-      });
-    },
-  };
-};

--- a/src/presentation/hooks/useStorageItem/useStorageItem.ts
+++ b/src/presentation/hooks/useStorageItem/useStorageItem.ts
@@ -1,0 +1,35 @@
+import { storage } from "#imports";
+
+export interface StorageHook<T> {
+  setItem: (value: T) => Promise<void>;
+  getItem: () => Promise<T>;
+  watchItem: (callback: (value: T) => void) => void;
+}
+
+/**
+ * Factory that creates a typed localStorage hook backed by WXT storage.
+ * Returns a hook function with `setItem`, `getItem`, and `watchItem` methods.
+ *
+ * @param key - The storage key (without the `local:` prefix)
+ * @param fallback - The default value when no stored value exists
+ */
+export const createStorageHook = <T>(
+  key: string,
+  fallback: T,
+): (() => StorageHook<T>) => {
+  const storageItem = storage.defineItem<T>(`local:${key}`, { fallback });
+
+  return (): StorageHook<T> => ({
+    setItem: async (value: T): Promise<void> => {
+      await storageItem.setValue(value);
+    },
+    getItem: async (): Promise<T> => {
+      return await storageItem.getValue();
+    },
+    watchItem: (callback: (value: T) => void): void => {
+      storageItem.watch((newValue) => {
+        callback(newValue);
+      });
+    },
+  });
+};

--- a/src/presentation/hooks/useSubtitleBgColor/useSubtitleBgColor.ts
+++ b/src/presentation/hooks/useSubtitleBgColor/useSubtitleBgColor.ts
@@ -1,41 +1,8 @@
-import { storage } from "#imports";
 import { GLOBAL_STRINGS } from "~@/config/utils/globalStrings";
 
-type SetValue = (value: string) => Promise<void>;
-type GetValue = () => Promise<string>;
-type WatchItem = (callback: (value: string) => void) => void;
+import { createStorageHook } from "../useStorageItem/useStorageItem";
 
-interface IUseSubtitleBgColor {
-  setItem: SetValue;
-  getItem: GetValue;
-  watchItem: WatchItem;
-}
-
-const subtitleBgColor = storage.defineItem<string>(
-  `local:${GLOBAL_STRINGS.STORAGE_KEYS.SUBTITLE_BG_COLOR}`,
-  {
-    fallback: "#000000",
-  },
+export const useSubtitleBgColor = createStorageHook<string>(
+  GLOBAL_STRINGS.STORAGE_KEYS.SUBTITLE_BG_COLOR,
+  "#000000",
 );
-
-/**
- * Hook to manage the subtitle display background color.
- * Provides methods to set, get, and watch the background color value in local storage.
- *
- * @returns {IUseSubtitleBgColor} Methods to interact with the subtitle background color.
- */
-export const useSubtitleBgColor = (): IUseSubtitleBgColor => {
-  return {
-    setItem: async (value: string): Promise<void> => {
-      await subtitleBgColor.setValue(value);
-    },
-    getItem: async (): Promise<string> => {
-      return await subtitleBgColor.getValue();
-    },
-    watchItem: (callback: (value: string) => void) => {
-      subtitleBgColor.watch((newValue) => {
-        callback(newValue);
-      });
-    },
-  };
-};

--- a/src/presentation/hooks/useSubtitleFontColor/useSubtitleFontColor.ts
+++ b/src/presentation/hooks/useSubtitleFontColor/useSubtitleFontColor.ts
@@ -1,41 +1,8 @@
-import { storage } from "#imports";
 import { GLOBAL_STRINGS } from "~@/config/utils/globalStrings";
 
-type SetValue = (value: string) => Promise<void>;
-type GetValue = () => Promise<string>;
-type WatchItem = (callback: (value: string) => void) => void;
+import { createStorageHook } from "../useStorageItem/useStorageItem";
 
-interface IUseSubtitleFontColor {
-  setItem: SetValue;
-  getItem: GetValue;
-  watchItem: WatchItem;
-}
-
-const subtitleFontColor = storage.defineItem<string>(
-  `local:${GLOBAL_STRINGS.STORAGE_KEYS.SUBTITLE_FONT_COLOR}`,
-  {
-    fallback: "#ffffff",
-  },
+export const useSubtitleFontColor = createStorageHook<string>(
+  GLOBAL_STRINGS.STORAGE_KEYS.SUBTITLE_FONT_COLOR,
+  "#ffffff",
 );
-
-/**
- * Hook to manage the subtitle display font color.
- * Provides methods to set, get, and watch the font color value in local storage.
- *
- * @returns {IUseSubtitleFontColor} Methods to interact with the subtitle font color.
- */
-export const useSubtitleFontColor = (): IUseSubtitleFontColor => {
-  return {
-    setItem: async (value: string): Promise<void> => {
-      await subtitleFontColor.setValue(value);
-    },
-    getItem: async (): Promise<string> => {
-      return await subtitleFontColor.getValue();
-    },
-    watchItem: (callback: (value: string) => void) => {
-      subtitleFontColor.watch((newValue) => {
-        callback(newValue);
-      });
-    },
-  };
-};

--- a/src/presentation/hooks/useSubtitleFontSize/useSubtitleFontSize.ts
+++ b/src/presentation/hooks/useSubtitleFontSize/useSubtitleFontSize.ts
@@ -1,41 +1,8 @@
-import { storage } from "#imports";
 import { GLOBAL_STRINGS } from "~@/config/utils/globalStrings";
 
-type SetValue = (value: number) => Promise<void>;
-type GetValue = () => Promise<number>;
-type WatchItem = (callback: (value: number) => void) => void;
+import { createStorageHook } from "../useStorageItem/useStorageItem";
 
-interface IUseSubtitleFontSize {
-  setItem: SetValue;
-  getItem: GetValue;
-  watchItem: WatchItem;
-}
-
-const subtitleFontSize = storage.defineItem<number>(
-  `local:${GLOBAL_STRINGS.STORAGE_KEYS.SUBTITLE_FONT_SIZE}`,
-  {
-    fallback: 24,
-  },
+export const useSubtitleFontSize = createStorageHook<number>(
+  GLOBAL_STRINGS.STORAGE_KEYS.SUBTITLE_FONT_SIZE,
+  24,
 );
-
-/**
- * Hook to manage the subtitle display font size.
- * Provides methods to set, get, and watch the font size value in local storage.
- *
- * @returns {IUseSubtitleFontSize} Methods to interact with the subtitle font size.
- */
-export const useSubtitleFontSize = (): IUseSubtitleFontSize => {
-  return {
-    setItem: async (value: number): Promise<void> => {
-      await subtitleFontSize.setValue(value);
-    },
-    getItem: async (): Promise<number> => {
-      return await subtitleFontSize.getValue();
-    },
-    watchItem: (callback: (value: number) => void) => {
-      subtitleFontSize.watch((newValue) => {
-        callback(newValue);
-      });
-    },
-  };
-};

--- a/src/presentation/hooks/useTranslatorStatus/useTranslatorStatus.ts
+++ b/src/presentation/hooks/useTranslatorStatus/useTranslatorStatus.ts
@@ -1,69 +1,8 @@
-import { storage } from "#imports";
-
 import { GLOBAL_STRINGS } from "~@/config/utils/globalStrings";
 
-/**
- * Type alias for setting the translator status value.
- */
-type SetValue = (value: boolean) => Promise<void>;
+import { createStorageHook } from "../useStorageItem/useStorageItem";
 
-/**
- * Type alias for getting the translator status value.
- */
-type GetValue = () => Promise<boolean>;
-
-/**
- * Type alias for watching changes in the translator status value.
- */
-type WatchItem = (callback: (value: boolean) => void) => void;
-
-/**
- * Interface for the useTranslatorStatus hook.
- */
-interface IUseTranslatorStatus {
-  /**
-   * Sets the translator status.
-   * @param value - The boolean value to set.
-   * @returns A promise that resolves when the value is set.
-   */
-  setItem: SetValue;
-  /**
-   * Gets the current translator status.
-   * @returns A promise that resolves to the current boolean value.
-   */
-  getItem: GetValue;
-  /**
-   * Watches for changes in the translator status.
-   * @param callback - The function to call when the value changes.
-   */
-  watchItem: WatchItem;
-}
-
-const translatorStatus = storage.defineItem<boolean>(
-  `local:${GLOBAL_STRINGS.STORAGE_KEYS.TRANSLATOR_IS_ACTIVE}`,
-  {
-    fallback: true,
-  },
+export const useTranslatorStatus = createStorageHook<boolean>(
+  GLOBAL_STRINGS.STORAGE_KEYS.TRANSLATOR_IS_ACTIVE,
+  true,
 );
-
-/**
- * Hook to manage the translator active status.
- * Provides methods to set, get, and watch the status value in local storage.
- *
- * @returns {IUseTranslatorStatus} An object containing methods to interact with the translator status.
- */
-export const useTranslatorStatus = (): IUseTranslatorStatus => {
-  return {
-    setItem: async (value: boolean): Promise<void> => {
-      await translatorStatus.setValue(value);
-    },
-    getItem: async (): Promise<boolean> => {
-      return await translatorStatus.getValue();
-    },
-    watchItem: async (callback: (value: boolean) => void) => {
-      await translatorStatus.watch((newValue) => {
-        callback(newValue);
-      });
-    },
-  };
-};

--- a/src/presentation/hooks/useUpdateNotificationStatus/useUpdateNotificationStatus.ts
+++ b/src/presentation/hooks/useUpdateNotificationStatus/useUpdateNotificationStatus.ts
@@ -1,69 +1,8 @@
-import { storage } from "#imports";
-
 import { GLOBAL_STRINGS } from "~@/config/utils/globalStrings";
 
-/**
- * Type alias for setting the update notification last shown timestamp.
- */
-type SetValue = (value: number) => Promise<void>;
+import { createStorageHook } from "../useStorageItem/useStorageItem";
 
-/**
- * Type alias for getting the update notification last shown timestamp.
- */
-type GetValue = () => Promise<number>;
-
-/**
- * Type alias for watching changes in the update notification timestamp.
- */
-type WatchItem = (callback: (value: number) => void) => void;
-
-/**
- * Interface for the useUpdateNotificationStatus hook.
- */
-interface IUseUpdateNotificationStatus {
-  /**
-   * Sets the last shown timestamp for the update notification.
-   * @param value - Unix timestamp (ms) when the notification was last shown.
-   */
-  setItem: SetValue;
-  /**
-   * Gets the last shown timestamp for the update notification.
-   * @returns A promise that resolves to the timestamp, or 0 if never shown.
-   */
-  getItem: GetValue;
-  /**
-   * Watches for changes in the update notification timestamp.
-   * @param callback - The function to call when the value changes.
-   */
-  watchItem: WatchItem;
-}
-
-const updateNotificationLastShown = storage.defineItem<number>(
-  `local:${GLOBAL_STRINGS.STORAGE_KEYS.UPDATE_NOTIFICATION_LAST_SHOWN}`,
-  {
-    fallback: 0,
-  },
+export const useUpdateNotificationStatus = createStorageHook<number>(
+  GLOBAL_STRINGS.STORAGE_KEYS.UPDATE_NOTIFICATION_LAST_SHOWN,
+  0,
 );
-
-/**
- * Hook to manage the update notification throttling state.
- * Uses local storage so the timestamp persists across browser restarts.
- * Provides methods to set, get, and watch the last shown timestamp.
- *
- * @returns {IUseUpdateNotificationStatus} An object containing methods to interact with the notification status.
- */
-export const useUpdateNotificationStatus = (): IUseUpdateNotificationStatus => {
-  return {
-    setItem: async (value: number): Promise<void> => {
-      await updateNotificationLastShown.setValue(value);
-    },
-    getItem: async (): Promise<number> => {
-      return await updateNotificationLastShown.getValue();
-    },
-    watchItem: (callback: (value: number) => void) => {
-      updateNotificationLastShown.watch((newValue) => {
-        callback(newValue);
-      });
-    },
-  };
-};


### PR DESCRIPTION
## Release 1.5.0

### Overview
This release refactors the 10 duplicated WXT storage hooks into a single generic `createStorageHook<T>` factory, eliminating ~417 lines of repeated boilerplate. The public interface of each hook is preserved, so no consumer changes are required.

### Changes

### Changed

- Extract storage hook factory to eliminate duplicated WXT storage boilerplate across 10 hooks (50adf78)

### Checklist
- [x] CHANGELOG reviewed
- [x] Tests passing
- [x] No breaking changes undocumented