### PR TITLE
🔖 release: 1.5.0

### DIFF
--- a/docs/sdd/.sdd-state.json
+++ b/docs/sdd/.sdd-state.json
@@ -7,7 +7,7 @@
       "name": "traductor-textos-seleccionados",
       "phase": "tasks",
       "phase_status": "approved",
-      "current_task": "APP-002",
+      "current_task": "UI-002",
       "files": {
         "spec": "docs/sdd/specs/SPEC-001-traductor-textos-seleccionados.md",
         "plan": "docs/sdd/plans/PLAN-SPEC-001.md",

--- a/docs/sdd/.sdd-state.json
+++ b/docs/sdd/.sdd-state.json
@@ -7,7 +7,7 @@
       "name": "traductor-textos-seleccionados",
       "phase": "tasks",
       "phase_status": "approved",
-      "current_task": "UI-003",
+      "current_task": "UI-004",
       "files": {
         "spec": "docs/sdd/specs/SPEC-001-traductor-textos-seleccionados.md",
         "plan": "docs/sdd/plans/PLAN-SPEC-001.md",

--- a/docs/sdd/.sdd-state.json
+++ b/docs/sdd/.sdd-state.json
@@ -7,7 +7,7 @@
       "name": "traductor-textos-seleccionados",
       "phase": "tasks",
       "phase_status": "approved",
-      "current_task": "UI-006",
+      "current_task": "done",
       "files": {
         "spec": "docs/sdd/specs/SPEC-001-traductor-textos-seleccionados.md",
         "plan": "docs/sdd/plans/PLAN-SPEC-001.md",

--- a/docs/sdd/.sdd-state.json
+++ b/docs/sdd/.sdd-state.json
@@ -7,7 +7,7 @@
       "name": "traductor-textos-seleccionados",
       "phase": "tasks",
       "phase_status": "approved",
-      "current_task": "UI-002",
+      "current_task": "UI-003",
       "files": {
         "spec": "docs/sdd/specs/SPEC-001-traductor-textos-seleccionados.md",
         "plan": "docs/sdd/plans/PLAN-SPEC-001.md",

--- a/docs/sdd/.sdd-state.json
+++ b/docs/sdd/.sdd-state.json
@@ -1,0 +1,16 @@
+{
+  "version": "1.0",
+  "project": "sctools",
+  "initialized": "2026-04-15",
+  "specs": {
+    "SPEC-001": {
+      "name": "traductor-textos-seleccionados",
+      "phase": "tasks",
+      "phase_status": "draft",
+      "files": {
+        "spec": "docs/sdd/specs/SPEC-001-traductor-textos-seleccionados.md",
+        "plan": "docs/sdd/plans/PLAN-SPEC-001.md"
+      }
+    }
+  }
+}

--- a/docs/sdd/.sdd-state.json
+++ b/docs/sdd/.sdd-state.json
@@ -7,7 +7,7 @@
       "name": "traductor-textos-seleccionados",
       "phase": "tasks",
       "phase_status": "approved",
-      "current_task": "UI-004",
+      "current_task": "UI-006",
       "files": {
         "spec": "docs/sdd/specs/SPEC-001-traductor-textos-seleccionados.md",
         "plan": "docs/sdd/plans/PLAN-SPEC-001.md",

--- a/docs/sdd/.sdd-state.json
+++ b/docs/sdd/.sdd-state.json
@@ -6,10 +6,12 @@
     "SPEC-001": {
       "name": "traductor-textos-seleccionados",
       "phase": "tasks",
-      "phase_status": "draft",
+      "phase_status": "approved",
+      "current_task": "APP-002",
       "files": {
         "spec": "docs/sdd/specs/SPEC-001-traductor-textos-seleccionados.md",
-        "plan": "docs/sdd/plans/PLAN-SPEC-001.md"
+        "plan": "docs/sdd/plans/PLAN-SPEC-001.md",
+        "tasks": "docs/sdd/tasks/TASKS-SPEC-001.md"
       }
     }
   }

--- a/docs/sdd/plans/PLAN-SPEC-001.md
+++ b/docs/sdd/plans/PLAN-SPEC-001.md
@@ -1,0 +1,245 @@
+# Plan Técnico SPEC-001: Traductor de Textos Seleccionados
+
+> **Ref. Spec:** [SPEC-001](../specs/SPEC-001-traductor-textos-seleccionados.md)
+> **Versión:** 1.0 | **Fecha:** 2026-04-15 | **Autor:** Claude (SDD Agent)
+
+---
+
+## 1. Decisión Arquitectónica (Resumen)
+
+- **Patrón elegido:** Content Script global + Background Handler (patrón existente del proyecto)
+- **Justificación:** El proyecto ya enruta toda traducción a través del service worker (`background/controller.ts`). El nuevo feature sigue el mismo patrón: el content script maneja DOM/UI, el background ejecuta la Translator API. Esto mantiene consistencia y centraliza el acceso a la API de Chrome AI en una sola capa.
+- **Impacto en módulos existentes:**
+  - `background/controller.ts` — nuevo método `handleSelectionMessage`
+  - `background/index.ts` — nuevo case `SELECTION_MESSAGE`
+  - `globalStrings.ts` — nueva storage key + nuevo message type
+  - `useFeaturesStatus` — nuevo feature `selectionTranslator`
+  - `PopupContent.tsx` — nuevo `ExtensionToggle` en pestaña Funcionalidades
+
+---
+
+## 2. Estructura de Módulos / Capas
+
+```
+src/
+  config/utils/
+    globalStrings.ts                         → [MODIFICAR] nueva STORAGE_KEY + BG_MESSAGE_TYPE
+
+  infrastructure/datasource/
+    (sin cambios — localTranslator y localLanguageDetector ya existen)
+
+  presentation/
+    entrypoints/
+      selectionLocalTranslator.content/
+        index.tsx                            → [NUEVO] content script, matches: <all_urls>
+
+    components/
+      SelectionLocalTranslator/
+        SelectionLocalTranslator.tsx         → [NUEVO] componente raíz (orchestrador)
+        SelectionBubble/
+          SelectionBubble.tsx                → [NUEVO] burbuja flotante sobre selección
+          __test__/
+            SelectionBubble.test.tsx
+        SelectionTooltip/
+          SelectionTooltip.tsx               → [NUEVO] panel con traducción y controles
+          __test__/
+            SelectionTooltip.test.tsx
+        hooks/
+          useTextSelection.ts                → [NUEVO] detecta selección y calcula posición
+          useSelectionTranslation.ts         → [NUEVO] gestiona estado de traducción
+          __test__/
+            useTextSelection.test.ts
+            useSelectionTranslation.test.ts
+
+    hooks/
+      useSelectionTranslatorStatus/
+        useSelectionTranslatorStatus.ts      → [NUEVO] storage hook para toggle on/off
+        useSelectionTranslatorStatus.test.ts
+
+      useFeaturesStatus/
+        useFeaturesStatus.ts                 → [MODIFICAR] agregar selectionTranslator
+
+    components/
+      Popup/
+        PopupContent/
+          PopupContent.tsx                   → [MODIFICAR] nuevo ExtensionToggle
+
+    entrypoints/
+      background/
+        controller.ts                        → [MODIFICAR] nuevo handleSelectionMessage
+        index.ts                             → [MODIFICAR] nuevo case SELECTION_MESSAGE
+```
+
+---
+
+## 3. Modelos de Datos
+
+```typescript
+// Estado de una selección de texto activa
+interface TextSelection {
+  text: string
+  rect: DOMRect   // posición en pantalla para ubicar la burbuja
+}
+
+// Estado de la traducción
+type TranslationStatus = 'idle' | 'translating' | 'downloading' | 'done' | 'error'
+
+interface TranslationState {
+  status: TranslationStatus
+  translatedText: string | null
+  sourceLanguage: string | null
+  downloadProgress?: number   // [0, 1] — AC: Edge case #2 (modelo descargando)
+  errorMessage?: string       // AC: Edge case #3 y #4
+}
+
+// Mensaje enviado al background (nuevo tipo)
+interface SelectionMessagePayload {
+  type: 'SELECTION_MESSAGE'
+  data: string          // texto seleccionado
+  target: string        // idioma destino (ej: "es")
+  onProgress?: never    // el progreso se maneja por callback separado
+}
+
+// Respuesta del background
+interface SelectionMessageResponse {
+  translatedText: string
+  sourceLanguage: string
+}
+```
+
+---
+
+## 4. Contratos: Casos de Uso e Interfaces
+
+### Hook: `useTextSelection`
+
+```typescript
+interface UseTextSelectionReturn {
+  selection: TextSelection | null   // null cuando no hay selección válida (< 3 chars)
+  clearSelection: () => void
+}
+
+// Lógica interna:
+// - Escucha evento 'selectionchange' en document
+// - Filtra: text.trim().length < 3 → selection = null (AC-02)
+// - clearSelection: window.getSelection()?.removeAllRanges()
+```
+
+### Hook: `useSelectionTranslation`
+
+```typescript
+interface UseSelectionTranslationReturn {
+  state: TranslationState
+  translate: (text: string, targetLanguage: string) => Promise<void>
+}
+
+// Lógica interna:
+// - translate() envía SELECTION_MESSAGE al background
+// - Maneja estados: translating → done | error (AC-03, AC-04)
+// - Descarga del modelo: el background llama onProgress via callback
+//   NOTE: La Translator API no permite progreso async cross-message.
+//   Alternativa: el background retorna un objeto con translatedText o
+//   un indicador de "downloading". Ver ADR-001.
+```
+
+### Background: `handleSelectionMessage`
+
+```typescript
+// En backgroundController:
+handleSelectionMessage: async (
+  text: string,
+  targetLanguage: string,
+  onProgress?: (loaded: number) => void
+) => Promise<{ translatedText: string; sourceLanguage: string } | undefined>
+
+// Lógica:
+// 1. localLanguageDetector.detectLanguage(text) → sourceLanguage (AC-04)
+// 2. localTranslator.create({ sourceLanguage, targetLanguage, onProgress })
+// 3. translator.translate(text) → translatedText
+// 4. Return { translatedText, sourceLanguage }
+// No bloquea si source === target (AC-05): Chrome Translator lo maneja nativamente
+```
+
+### Hook: `useSelectionTranslatorStatus`
+
+```typescript
+// Usa createStorageHook<boolean> — patrón idéntico a useTranslatorStatus
+export const useSelectionTranslatorStatus = createStorageHook<boolean>(
+  GLOBAL_STRINGS.STORAGE_KEYS.SELECTION_TRANSLATOR_IS_ACTIVE,
+  true   // por defecto activado
+)
+```
+
+---
+
+## 5. Contratos de API HTTP / IPC
+
+No aplica HTTP. Contrato IPC (browser runtime messages):
+
+```
+Emisor:    content script selectionLocalTranslator.content
+Receptor:  background/index.ts
+
+Request:
+  { type: 'SELECTION_MESSAGE', data: string, target: string }
+
+Response (éxito):
+  { translatedText: string, sourceLanguage: string }
+
+Response (error / API no disponible):
+  undefined  → el content script muestra el estado de error adecuado
+```
+
+---
+
+## 6. Estrategia de Error Handling
+
+| Capa          | Condición                                     | Representación                        | UI mostrada                                      |
+| ------------- | --------------------------------------------- | ------------------------------------- | ------------------------------------------------ |
+| Content/Hook  | `text.trim().length < 3`                      | `selection = null`                    | Burbuja no aparece (AC-02)                       |
+| Background    | `!localTranslator.isAvailable()`              | Retorna `undefined`                   | "Funcionalidad no disponible en este navegador" (Edge #4) |
+| Background    | Modelo descargando                            | `onProgress` callback (ver ADR-001)   | Indicador de progreso con porcentaje (Edge #2)   |
+| Background    | Error de red durante descarga                 | `catch → return undefined`            | Mensaje de error + botón reintentar (Edge #3)    |
+| Content/Hook  | `response === undefined`                      | `TranslationState.status = 'error'`   | Mensaje de error en tooltip                      |
+| UI            | Nueva selección con tooltip abierto           | clearSelection() + reset state        | Tooltip anterior cierra, nueva burbuja (Edge #5) |
+| UI            | Scroll mientras tooltip visible               | `scroll` event listener → clear       | Tooltip se cierra (Edge #6)                      |
+
+---
+
+## 7. Estrategia de Testing
+
+| Módulo                          | Tipo         | Herramienta              | Qué cubrir                                                      |
+| ------------------------------- | ------------ | ------------------------ | --------------------------------------------------------------- |
+| `useTextSelection`              | Unit         | Vitest + happy-dom       | selección válida, filtro < 3 chars, whitespace, clearSelection  |
+| `useSelectionTranslatorStatus`  | Unit         | Vitest                   | getItem/setItem/watchItem — patrón existente en otros hooks     |
+| `backgroundController.handleSelectionMessage` | Unit | Vitest + mocks | traducción exitosa, API no disponible, source === target        |
+| `SelectionBubble`               | Component    | Testing Library          | render con posición, no render sin selección                    |
+| `SelectionTooltip`              | Component    | Testing Library          | estados: translating, done, error, downloading; botón copiar   |
+| `useSelectionTranslation`       | Unit         | Vitest                   | estados de la máquina: idle→translating→done, idle→error       |
+
+**Cobertura mínima:** happy path + todos los edge cases definidos en la spec.
+
+---
+
+## 8. Log de Decisiones (ADR)
+
+| Fecha      | Decisión                                                              | Alternativas descartadas                                    | Razón                                                                                                            |
+| ---------- | --------------------------------------------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| 2026-04-15 | Traducción vía background (mensaje IPC)                              | Llamar Translator API directamente desde content script     | Consistencia con el patrón existente (AC-04 requiere detect + translate, que ya está en `handleChatMessage`)     |
+| 2026-04-15 | Burbuja aparece al selección, tooltip al hacer hover                 | Tooltip directo al soltar el mouse                          | AC-01 define burbuja pequeña → hover → tooltip. Reduce ruido visual al seleccionar accidentalmente               |
+| 2026-04-15 | Traducir en el momento del hover (lazy), no al seleccionar           | Pre-traducir al detectar selección                          | AC-03 dice "cuando el usuario hace hover... se expande un tooltip que muestra la traducción". Evita traducciones no usadas |
+| 2026-04-15 | ADR-001: Progreso de descarga — retornar status 'downloading' desde background, content script polling | Callback onProgress cross-message | `browser.runtime.sendMessage` es request/response: no soporta callbacks intermedios. La alternativa es que el background retorne `{ status: 'downloading' }` y el content script reintenta hasta obtener `{ status: 'done', translatedText }` con un pequeño delay. O bien, mostrar spinner sin porcentaje exacto. **Decisión: spinner sin porcentaje** (simplifica el IPC; el porcentaje exacto no es requerimiento AC, solo edge case #2 menciona "indicador de progreso con porcentaje" — ver si el usuario quiere reconsiderar este detalle) |
+| 2026-04-15 | Content script en `<all_urls>` con `matches: ["*://*/*"]`             | Listar dominios específicos                                 | AC-01 requiere "cualquier sitio web". Shadow DOM garantiza aislamiento de estilos (AC NFR)                       |
+| 2026-04-15 | Reusar `useLocalTranslatorTargetLanguage` para idioma destino        | Hook nuevo exclusivo para selection translator              | AC-08 requiere persistencia. El storage key existente `localTranslatorTargetLanguage` ya cumple — mismo idioma destino para toda la extensión es UX coherente |
+
+---
+
+## 9. Riesgos y Dependencias Externas
+
+| Riesgo / Dependencia                             | Probabilidad | Impacto | Mitigación                                                                                     |
+| ------------------------------------------------ | ------------ | ------- | ---------------------------------------------------------------------------------------------- |
+| Translator API no disponible (Chrome < 138)      | Media        | Alto    | Verificar `localTranslator.isAvailable()` antes de activar el feature; mostrar mensaje claro   |
+| Content script bloqueado por CSP de la página   | Baja         | Medio   | Shadow DOM es inyectado por el extension runtime, no por el CSP de la página (Edge #8 de spec) |
+| Interferencia con otros event listeners de la página | Baja     | Bajo    | Usar `selectionchange` en `document` con `{ capture: false }` y limpiar en cleanup del hook   |
+| Progreso de descarga no reportable via IPC       | Alta         | Bajo    | ADR-001: spinner sin porcentaje exacto. Si el usuario requiere porcentaje, se extiende con `browser.runtime.connect` (Long-lived connection) en una iteración futura |
+| Permiso `<all_urls>` en manifest                 | Media        | Medio   | WXT genera el manifest automáticamente desde el `matches` del content script. Verificar que no requiera host_permissions adicional |

--- a/docs/sdd/specs/SPEC-001-traductor-textos-seleccionados.md
+++ b/docs/sdd/specs/SPEC-001-traductor-textos-seleccionados.md
@@ -1,0 +1,162 @@
+# Spec SPEC-001: Traductor de Textos Seleccionados
+
+> **Versión:** 1.0 | **Fecha:** 2026-04-15 | **Estado:** aprobado
+> **Autor:** Claude (SDD Agent) | **Revisado por:** Juan Pablo Leon (2026-04-15)
+
+---
+
+## 1. Contexto y Problema
+
+- **Problema concreto:** La funcionalidad de traducción está limitada a 4 camsites específicos (StripChat, Chaturbate, SM, CamSoda). Los usuarios necesitan traducir textos en otros sitios web y recurren a extensiones externas como QTranslate, que causa interferencia con el funcionamiento principal de redna-models.
+- **Motivación:** Ampliar la cobertura del servicio de traducción para eliminar la dependencia de extensiones de terceros que generan conflictos. Reducir fricción del usuario al consolidar toda la traducción en una sola herramienta.
+- **Fuera de alcance:**
+  - No incluye: traducción de página completa (full-page translation)
+  - No incluye: traducción de texto en imágenes (OCR)
+  - No incluye: edición o reemplazo del texto original en la página
+
+---
+
+## 2. Historias de Usuario
+
+| ID    | Como                  | Quiero                                                                                   | Para                                                              |
+| ----- | --------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| US-01 | Modelo webcam (usuario) | seleccionar texto en cualquier sitio web y ver su traducción en un tooltip              | entender contenido en otros idiomas sin salir de la página        |
+| US-02 | Modelo webcam (usuario) | elegir el idioma destino de la traducción desde el tooltip                               | traducir al idioma que necesite en cada momento                   |
+| US-03 | Modelo webcam (usuario) | copiar la traducción al portapapeles con un click                                        | usar el texto traducido en otra parte rápidamente                 |
+| US-04 | Modelo webcam (usuario) | activar o desactivar esta funcionalidad desde el popup de la extensión                   | controlar cuándo la burbuja de traducción aparece al seleccionar  |
+
+---
+
+## 3. Criterios de Aceptación
+
+### US-01 — Traducción de texto seleccionado
+
+**AC-01: Burbuja aparece al seleccionar texto (≥3 caracteres)**
+- **Dado que** la funcionalidad está activada y el usuario está en cualquier sitio web
+- **Cuando** selecciona texto de 3 o más caracteres
+- **Entonces** aparece una burbuja pequeña con el logo EW posicionada justo encima de la selección
+
+**AC-02: Burbuja NO aparece con selección menor a 3 caracteres**
+- **Dado que** la funcionalidad está activada
+- **Cuando** el usuario selecciona texto de menos de 3 caracteres (o solo espacios en blanco)
+- **Entonces** no aparece ninguna burbuja
+
+**AC-03: Hover en burbuja despliega tooltip con traducción**
+- **Dado que** la burbuja EW es visible sobre una selección de texto
+- **Cuando** el usuario hace hover sobre la burbuja
+- **Entonces** se expande un tooltip que muestra la traducción del texto seleccionado, con el idioma fuente auto-detectado y el idioma destino configurado (español por defecto)
+
+**AC-04: Detección automática del idioma fuente**
+- **Dado que** el usuario seleccionó texto y el tooltip se está desplegando
+- **Cuando** el sistema procesa la traducción
+- **Entonces** detecta automáticamente el idioma del texto seleccionado usando la Language Detector API y lo usa como idioma fuente para la traducción
+
+**AC-05: Traducción cuando idioma fuente coincide con destino**
+- **Dado que** el texto seleccionado está en el mismo idioma que el idioma destino configurado
+- **Cuando** el tooltip se despliega
+- **Entonces** se muestra el texto traducido normalmente (sin bloqueo ni mensaje especial)
+
+### US-02 — Selector de idioma destino
+
+**AC-06: Dropdown de idioma destino en el tooltip**
+- **Dado que** el tooltip de traducción está visible
+- **Cuando** el usuario observa el tooltip
+- **Entonces** ve un menú desplegable con el idioma destino actual (español por defecto) que permite cambiar a otros idiomas disponibles
+
+**AC-07: Cambio de idioma destino re-traduce el texto**
+- **Dado que** el tooltip muestra una traducción y el usuario cambia el idioma destino en el dropdown
+- **Cuando** selecciona un nuevo idioma
+- **Entonces** el texto se re-traduce al nuevo idioma seleccionado y el tooltip actualiza su contenido
+
+**AC-08: Idioma destino persiste entre sesiones**
+- **Dado que** el usuario cambió el idioma destino en el tooltip
+- **Cuando** realiza una nueva selección de texto (en la misma o diferente página)
+- **Entonces** el idioma destino seleccionado previamente se mantiene como valor por defecto
+
+### US-03 — Copiar traducción
+
+**AC-09: Botón copiar en el tooltip**
+- **Dado que** el tooltip muestra una traducción completada
+- **Cuando** el usuario hace click en el botón/ícono de copiar
+- **Entonces** el texto traducido se copia al portapapeles del sistema y se muestra feedback visual de confirmación (ej: ícono cambia a checkmark por 2 segundos)
+
+### US-04 — Toggle de activación
+
+**AC-10: Switch visible en el popup de la extensión**
+- **Dado que** el usuario abre el popup de redna-models
+- **Cuando** navega a la pestaña "Funcionalidades"
+- **Entonces** ve un toggle "Traductor de Selección" con estado encendido/apagado
+
+**AC-11: Desactivar la funcionalidad**
+- **Dado que** el toggle está encendido y el usuario lo desactiva
+- **Cuando** selecciona texto en cualquier página
+- **Entonces** no aparece ninguna burbuja ni tooltip de traducción
+
+**AC-12: Activar la funcionalidad**
+- **Dado que** el toggle estaba apagado y el usuario lo enciende
+- **Cuando** selecciona texto (≥3 caracteres) en cualquier página
+- **Entonces** la burbuja de traducción aparece normalmente
+
+---
+
+## 4. Requisitos No Funcionales
+
+| Categoría      | Requisito                                          | Métrica / Umbral                        |
+| -------------- | -------------------------------------------------- | --------------------------------------- |
+| Rendimiento    | Tiempo de aparición de la burbuja tras selección   | < 100ms                                 |
+| Rendimiento    | Tiempo de traducción (modelo ya descargado)        | < 2s para textos de hasta 500 chars     |
+| Compatibilidad | Navegador soportado                                | Chrome 138+ (requerido por Translator API) |
+| UX             | Burbuja no debe interferir con la interacción de la página | La burbuja no bloquea clicks en la página subyacente |
+| UX             | Tooltip no debe cubrir el texto seleccionado       | Posicionado encima o debajo sin solapar la selección |
+| Aislamiento    | Estilos del tooltip no afectan la página host      | Shadow DOM con CSS encapsulado          |
+
+---
+
+## 5. Casos de Borde y Errores
+
+| #  | Caso                              | Entrada / Condición                              | Comportamiento Esperado                                                    |
+| -- | --------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------- |
+| 1  | Selección solo espacios           | Texto seleccionado es solo whitespace             | No aparece burbuja                                                         |
+| 2  | Modelo no descargado              | Translator API requiere descarga del modelo       | Tooltip muestra indicador de progreso de descarga con porcentaje           |
+| 3  | Descarga falla                    | Error de red durante descarga del modelo          | Tooltip muestra mensaje de error con opción de reintentar                  |
+| 4  | API no disponible                 | Translator API o LanguageDetector no disponibles  | Tooltip muestra mensaje "Funcionalidad no disponible en este navegador"    |
+| 5  | Nueva selección con tooltip abierto | Usuario selecciona otro texto mientras tooltip visible | Tooltip anterior se cierra, nueva burbuja aparece en nueva selección    |
+| 6  | Scroll con tooltip abierto        | Usuario hace scroll mientras tooltip está visible | Tooltip se cierra automáticamente                                          |
+| 7  | Selección en input/textarea       | Texto seleccionado dentro de un campo editable    | Burbuja aparece normalmente (el texto es seleccionable)                    |
+| 8  | Página con Content Security Policy | CSP restrictiva bloquea inyección                | Content script con Shadow DOM funciona independientemente del CSP de la página |
+
+---
+
+## 6. Dependencias con Otras Specs
+
+- **Depende de:** Ninguna — usa infraestructura existente (localTranslator, localLanguageDetector)
+- **Requerida por:** Ninguna
+- **Relacionada:** Funcionalidad de traducción de chat en camsites (comparte infraestructura de traducción)
+
+---
+
+## 7. Glosario del Dominio
+
+| Término               | Definición en este contexto                                                                                  |
+| --------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Burbuja               | Elemento UI pequeño (logo EW) que aparece sobre el texto seleccionado como disparador de la traducción       |
+| Tooltip               | Panel expandido que se muestra al hacer hover en la burbuja, contiene la traducción y controles              |
+| Camsite               | Sitio web de modelaje webcam (StripChat, Chaturbate, SM, CamSoda)                                           |
+| Modelo de traducción  | Modelo de ML descargado localmente por la Translator API de Chrome para traducir entre un par de idiomas     |
+| EW                    | Estrellas Webcam — marca del producto redna-models                                                                |
+
+---
+
+## 8. Preguntas Abiertas
+
+| #  | Pregunta                                                              | Responsable | Fecha límite | Resolución |
+| -- | --------------------------------------------------------------------- | ----------- | ------------ | ---------- |
+| —  | No hay preguntas abiertas                                             | —           | —            | —          |
+
+---
+
+## 9. Historial de Cambios
+
+| Versión | Fecha      | Cambio                                            | Autor              |
+| ------- | ---------- | ------------------------------------------------- | ------------------- |
+| 1.0     | 2026-04-15 | Versión inicial                                   | Claude (SDD Agent)  |

--- a/docs/sdd/tasks/TASKS-SPEC-001.md
+++ b/docs/sdd/tasks/TASKS-SPEC-001.md
@@ -229,8 +229,8 @@ CONFIG-001
 | UI-001    | Hook `useSelectionTranslatorStatus`                | ✅ done | src/presentation/hooks/useSelectionTranslatorStatus/ | —     |
 | UI-002    | Hook `useTextSelection`                            | ✅ done | src/presentation/components/SelectionLocalTranslator/hooks/useTextSelection.ts | —     |
 | UI-003    | Hook `useSelectionTranslation`                     | ✅ done | src/presentation/components/SelectionLocalTranslator/hooks/useSelectionTranslation.ts | —     |
-| UI-004    | Componente `SelectionBubble`                       | ⬜ pendiente | —           | —     |
-| UI-005    | Componente `SelectionTooltip`                      | ⬜ pendiente | —           | —     |
+| UI-004    | Componente `SelectionBubble`                       | ✅ done | src/presentation/components/SelectionLocalTranslator/SelectionBubble/SelectionBubble.tsx | —     |
+| UI-005    | Componente `SelectionTooltip`                      | ✅ done | src/presentation/components/SelectionLocalTranslator/SelectionTooltip/SelectionTooltip.tsx | —     |
 | UI-006    | Componente `SelectionLocalTranslator` + entrypoint | ⬜ pendiente | —           | —     |
 | UI-007    | `selectionTranslator` en `useFeaturesStatus`       | ⬜ pendiente | —           | —     |
 | UI-008    | `ExtensionToggle` en `PopupContent`                | ⬜ pendiente | —           | —     |

--- a/docs/sdd/tasks/TASKS-SPEC-001.md
+++ b/docs/sdd/tasks/TASKS-SPEC-001.md
@@ -225,8 +225,8 @@ CONFIG-001
 | --------- | -------------------------------------------------- | ------------ | ----------- | ----- |
 | CONFIG-001 | Agregar storage key + message type a globalStrings | ✅ done | src/config/utils/globalStrings.ts | —     |
 | APP-001   | `handleSelectionMessage` en backgroundController   | ✅ done | src/presentation/entrypoints/background/controller.ts | —     |
-| APP-002   | Case `SELECTION_MESSAGE` en background/index.ts    | ⬜ pendiente | —           | —     |
-| UI-001    | Hook `useSelectionTranslatorStatus`                | ⬜ pendiente | —           | —     |
+| APP-002   | Case `SELECTION_MESSAGE` en background/index.ts    | ✅ done | src/presentation/entrypoints/background/index.ts | —     |
+| UI-001    | Hook `useSelectionTranslatorStatus`                | ✅ done | src/presentation/hooks/useSelectionTranslatorStatus/ | —     |
 | UI-002    | Hook `useTextSelection`                            | ⬜ pendiente | —           | —     |
 | UI-003    | Hook `useSelectionTranslation`                     | ⬜ pendiente | —           | —     |
 | UI-004    | Componente `SelectionBubble`                       | ⬜ pendiente | —           | —     |

--- a/docs/sdd/tasks/TASKS-SPEC-001.md
+++ b/docs/sdd/tasks/TASKS-SPEC-001.md
@@ -228,7 +228,7 @@ CONFIG-001
 | APP-002   | Case `SELECTION_MESSAGE` en background/index.ts    | ✅ done | src/presentation/entrypoints/background/index.ts | —     |
 | UI-001    | Hook `useSelectionTranslatorStatus`                | ✅ done | src/presentation/hooks/useSelectionTranslatorStatus/ | —     |
 | UI-002    | Hook `useTextSelection`                            | ✅ done | src/presentation/components/SelectionLocalTranslator/hooks/useTextSelection.ts | —     |
-| UI-003    | Hook `useSelectionTranslation`                     | ⬜ pendiente | —           | —     |
+| UI-003    | Hook `useSelectionTranslation`                     | ✅ done | src/presentation/components/SelectionLocalTranslator/hooks/useSelectionTranslation.ts | —     |
 | UI-004    | Componente `SelectionBubble`                       | ⬜ pendiente | —           | —     |
 | UI-005    | Componente `SelectionTooltip`                      | ⬜ pendiente | —           | —     |
 | UI-006    | Componente `SelectionLocalTranslator` + entrypoint | ⬜ pendiente | —           | —     |

--- a/docs/sdd/tasks/TASKS-SPEC-001.md
+++ b/docs/sdd/tasks/TASKS-SPEC-001.md
@@ -227,7 +227,7 @@ CONFIG-001
 | APP-001   | `handleSelectionMessage` en backgroundController   | ✅ done | src/presentation/entrypoints/background/controller.ts | —     |
 | APP-002   | Case `SELECTION_MESSAGE` en background/index.ts    | ✅ done | src/presentation/entrypoints/background/index.ts | —     |
 | UI-001    | Hook `useSelectionTranslatorStatus`                | ✅ done | src/presentation/hooks/useSelectionTranslatorStatus/ | —     |
-| UI-002    | Hook `useTextSelection`                            | ⬜ pendiente | —           | —     |
+| UI-002    | Hook `useTextSelection`                            | ✅ done | src/presentation/components/SelectionLocalTranslator/hooks/useTextSelection.ts | —     |
 | UI-003    | Hook `useSelectionTranslation`                     | ⬜ pendiente | —           | —     |
 | UI-004    | Componente `SelectionBubble`                       | ⬜ pendiente | —           | —     |
 | UI-005    | Componente `SelectionTooltip`                      | ⬜ pendiente | —           | —     |

--- a/docs/sdd/tasks/TASKS-SPEC-001.md
+++ b/docs/sdd/tasks/TASKS-SPEC-001.md
@@ -231,8 +231,8 @@ CONFIG-001
 | UI-003    | Hook `useSelectionTranslation`                     | ✅ done | src/presentation/components/SelectionLocalTranslator/hooks/useSelectionTranslation.ts | —     |
 | UI-004    | Componente `SelectionBubble`                       | ✅ done | src/presentation/components/SelectionLocalTranslator/SelectionBubble/SelectionBubble.tsx | —     |
 | UI-005    | Componente `SelectionTooltip`                      | ✅ done | src/presentation/components/SelectionLocalTranslator/SelectionTooltip/SelectionTooltip.tsx | —     |
-| UI-006    | Componente `SelectionLocalTranslator` + entrypoint | ⬜ pendiente | —           | —     |
-| UI-007    | `selectionTranslator` en `useFeaturesStatus`       | ⬜ pendiente | —           | —     |
-| UI-008    | `ExtensionToggle` en `PopupContent`                | ⬜ pendiente | —           | —     |
+| UI-006    | Componente `SelectionLocalTranslator` + entrypoint | ✅ done | src/presentation/components/SelectionLocalTranslator/SelectionLocalTranslator.tsx | —     |
+| UI-007    | `selectionTranslator` en `useFeaturesStatus`       | ✅ done | src/presentation/hooks/useFeaturesStatus/useFeaturesStatus.ts | —     |
+| UI-008    | `ExtensionToggle` en `PopupContent`                | ✅ done | src/presentation/components/Popup/PopupContent/PopupContent.tsx | —     |
 
 **Leyenda:** ⬜ pendiente | 🔄 en progreso | ✅ done | 🚫 bloqueado | ⏭️ descartado

--- a/docs/sdd/tasks/TASKS-SPEC-001.md
+++ b/docs/sdd/tasks/TASKS-SPEC-001.md
@@ -1,0 +1,238 @@
+# Tareas SPEC-001: Traductor de Textos Seleccionados
+
+> **Spec:** [SPEC-001](../specs/SPEC-001-traductor-textos-seleccionados.md) | **Plan:** [PLAN-SPEC-001](../plans/PLAN-SPEC-001.md)
+> **Fecha inicio:** 2026-04-16 | **Target release:** v1.5.0
+
+---
+
+## Convención de Tareas
+
+- **Granularidad:** cada tarea = 1 PR mínimo, idealmente 1 commit semántico.
+- **Naming:** `[CAPA] verbo + objeto` → ej: `[CONFIG] agregar storage key X`
+- **Definition of Done (global):** tests pasan en CI + `pnpm compile` limpio + revisado contra spec.
+- **Capas disponibles:** `[CONFIG]` `[APP]` `[UI]` `[TEST]`
+
+---
+
+## Tareas
+
+### [CONFIG] — Constantes y configuración global
+
+- [ ] **[CONFIG-001]** Agregar `SELECTION_TRANSLATOR_IS_ACTIVE` a `GLOBAL_STRINGS.STORAGE_KEYS` y `SELECTION_MESSAGE` a `GLOBAL_STRINGS.BG_MESSAGE_TYPE`
+  - **Archivo:** `src/config/utils/globalStrings.ts`
+  - **AC ref:** AC-10, AC-11, AC-12 (storage key para el toggle), AC-03 (message type para IPC)
+  - **Done cuando:** `pnpm compile` pasa sin errores; los nuevos campos son accesibles desde cualquier módulo importador
+  - **Bloqueado por:** —
+
+---
+
+### [APP] — Lógica de negocio / Background
+
+- [ ] **[APP-001]** Agregar `handleSelectionMessage` al `backgroundController` con detección de idioma y traducción dinámica (fuente auto-detectada, destino configurable)
+  - **Archivo:** `src/presentation/entrypoints/background/controller.ts`
+  - **AC ref:** AC-03 (traducción al hacer hover), AC-04 (detección automática idioma), AC-05 (source === target no bloquea)
+  - **Contrato:**
+    ```typescript
+    handleSelectionMessage: async (text: string, target: string) =>
+      Promise<{ translatedText: string; sourceLanguage: string } | undefined>
+    ```
+  - **Comportamiento edge:**
+    - Si `!localTranslator.isAvailable() || !localLanguageDetector.isAvailable()` → retorna `undefined` (Edge #4)
+    - Si `source === target` → deja que Chrome Translator maneje (no bloquear, per AC-05)
+  - **Done cuando:** tests en `__test__/controller.test.ts` cubren: happy path, API no disponible, source === target
+  - **Bloqueado por:** CONFIG-001
+
+- [ ] **[APP-002]** Registrar `SELECTION_MESSAGE` en el message router del background
+  - **Archivo:** `src/presentation/entrypoints/background/index.ts`
+  - **AC ref:** AC-03 (IPC funcional entre content script y background)
+  - **Done cuando:** nuevo `case GLOBAL_STRINGS.BG_MESSAGE_TYPE.SELECTION_MESSAGE:` añadido con el mismo patrón async que los casos existentes; `pnpm compile` limpio
+  - **Bloqueado por:** APP-001
+
+---
+
+### [UI] — Hooks
+
+- [ ] **[UI-001]** Crear hook `useSelectionTranslatorStatus` via `createStorageHook`
+  - **Archivo:** `src/presentation/hooks/useSelectionTranslatorStatus/useSelectionTranslatorStatus.ts`
+  - **AC ref:** AC-10, AC-11, AC-12 (toggle on/off persiste en storage)
+  - **Patrón:** idéntico a `useTranslatorStatus` — una línea con `createStorageHook<boolean>(STORAGE_KEY, true)`
+  - **Done cuando:** test `useSelectionTranslatorStatus.test.ts` cubre `getItem`, `setItem`, `watchItem`; default value es `true`
+  - **Bloqueado por:** CONFIG-001
+
+- [ ] **[UI-002]** Crear hook `useTextSelection` para detectar selección válida y calcular posición
+  - **Archivo:** `src/presentation/components/SelectionLocalTranslator/hooks/useTextSelection.ts`
+  - **AC ref:** AC-01 (burbuja aparece ≥3 chars), AC-02 (no aparece <3 chars / solo whitespace), Edge #5 (nueva selección reemplaza anterior), Edge #6 (scroll cierra)
+  - **Contrato:**
+    ```typescript
+    interface UseTextSelectionReturn {
+      selection: { text: string; rect: DOMRect } | null
+      clearSelection: () => void
+    }
+    ```
+  - **Lógica:** escucha `selectionchange` en `document`; filtra `text.trim().length < 3`; limpia en scroll (`scroll` event); cleanup en unmount
+  - **Done cuando:** tests en `__test__/useTextSelection.test.ts` cubren: selección válida, texto < 3 chars, solo whitespace, clearSelection, limpieza al scroll
+  - **Bloqueado por:** —
+
+- [ ] **[UI-003]** Crear hook `useSelectionTranslation` para gestionar el ciclo de vida de la traducción
+  - **Archivo:** `src/presentation/components/SelectionLocalTranslator/hooks/useSelectionTranslation.ts`
+  - **AC ref:** AC-03 (estado translating → done), AC-05 (sin bloqueo si mismo idioma), Edge #3 (error con retry), Edge #4 (API no disponible)
+  - **Contrato:**
+    ```typescript
+    type TranslationStatus = 'idle' | 'translating' | 'done' | 'error'
+    interface UseSelectionTranslationReturn {
+      status: TranslationStatus
+      translatedText: string | null
+      sourceLanguage: string | null
+      errorMessage?: string
+      translate: (text: string, targetLanguage: string) => Promise<void>
+      reset: () => void
+    }
+    ```
+  - **Lógica:** `translate()` envía `SELECTION_MESSAGE` al background; mapea `undefined` response a status `'error'`
+  - **Done cuando:** tests cubren máquina de estados: idle→translating→done, idle→translating→error, reset
+  - **Bloqueado por:** APP-002
+
+---
+
+### [UI] — Componentes
+
+- [ ] **[UI-004]** Crear componente `SelectionBubble` (burbuja flotante con logo EW sobre la selección)
+  - **Archivo:** `src/presentation/components/SelectionLocalTranslator/SelectionBubble/SelectionBubble.tsx`
+  - **AC ref:** AC-01 (burbuja aparece posicionada sobre selección), AC-02 (no render si selection es null), AC-03 (dispara traducción en hover)
+  - **Props:**
+    ```typescript
+    interface SelectionBubbleProps {
+      rect: DOMRect
+      onHover: () => void   // dispara translate en el padre
+    }
+    ```
+  - **Posicionamiento:** `position: fixed`, coordenadas calculadas desde `rect.top` y `rect.left + rect.width / 2`; usar `pointer-events: auto` en la burbuja, burbuja no bloquea clicks fuera (NFR)
+  - **Done cuando:** tests cubren: render con rect válido, no render si omitido; `onHover` se llama al `mouseenter`
+  - **Bloqueado por:** —
+
+- [ ] **[UI-005]** Crear componente `SelectionTooltip` (panel con traducción, selector de idioma y botón copiar)
+  - **Archivo:** `src/presentation/components/SelectionLocalTranslator/SelectionTooltip/SelectionTooltip.tsx`
+  - **AC ref:** AC-03 (muestra traducción), AC-06 (dropdown idioma destino), AC-07 (re-traduce al cambiar idioma), AC-08 (idioma persiste — via `useLocalTranslatorTargetLanguage`), AC-09 (botón copiar con feedback visual), Edge #3 (botón reintentar en error), Edge #4 (mensaje API no disponible)
+  - **Props:**
+    ```typescript
+    interface SelectionTooltipProps {
+      status: TranslationStatus
+      translatedText: string | null
+      sourceLanguage: string | null
+      errorMessage?: string
+      onRetry: () => void
+      onLanguageChange: (lang: string) => void
+      targetLanguage: string
+    }
+    ```
+  - **Nota AC-08:** usar hook existente `useLocalTranslatorTargetLanguage` para persistencia del idioma destino — no crear storage key nuevo
+  - **Done cuando:** tests cubren estados: translating (spinner), done (texto + idioma fuente), error (mensaje + retry), botón copiar (mock clipboard API, checkmark 2s)
+  - **Bloqueado por:** UI-003
+
+- [ ] **[UI-006]** Crear componente orquestador `SelectionLocalTranslator` y entrypoint de content script
+  - **Archivos:**
+    - `src/presentation/components/SelectionLocalTranslator/SelectionLocalTranslator.tsx` — componente raíz
+    - `src/presentation/entrypoints/selectionLocalTranslator.content/index.tsx` — entrypoint WXT con `createShadowRootUi`, `matches: ["*://*/*"]`
+  - **AC ref:** AC-01, AC-02 (orquesta useTextSelection → SelectionBubble), AC-03 (burbuja onHover → translate), AC-11 (si `!isEnabled` render null), AC-12 (si `isEnabled` render normal), Edge #5 (nueva selección cierra tooltip anterior — estado unificado en este componente), Edge #6 (clearSelection en scroll ya manejado por useTextSelection)
+  - **Lógica interna:**
+    - Lee `useSelectionTranslatorStatus()` → si false, retorna null
+    - Usa `useTextSelection()` para `selection`
+    - Usa `useSelectionTranslation()` para estado de traducción
+    - Muestra `SelectionBubble` cuando `selection !== null`
+    - Muestra `SelectionTooltip` cuando `isTooltipOpen` (estado local toggle por hover en burbuja)
+    - En nueva selección (selection cambia): reset translation state
+  - **Done cuando:** `pnpm dev` carga el content script en cualquier página; tests de integración del componente cubren: disabled no muestra nada, enabled + selección muestra burbuja, hover muestra tooltip
+  - **Bloqueado por:** UI-001, UI-002, UI-004, UI-005
+
+---
+
+### [UI] — Popup / Toggle
+
+- [ ] **[UI-007]** Agregar `selectionTranslator` a `useFeaturesStatus`
+  - **Archivo:** `src/presentation/hooks/useFeaturesStatus/useFeaturesStatus.ts`
+  - **AC ref:** AC-10 (toggle accesible desde popup), AC-11, AC-12
+  - **Cambios:** importar `useSelectionTranslatorStatus`; añadir a `Promise.all` en init; añadir `watchItem`; exponer `selectionTranslator: { isEnabled, toggle }` en el return
+  - **Done cuando:** test de `useFeaturesStatus` actualizado incluye `selectionTranslator` en el objeto retornado; `pnpm compile` limpio
+  - **Bloqueado por:** UI-001
+
+- [ ] **[UI-008]** Agregar `ExtensionToggle` para "Traductor de Selección" en `PopupContent`
+  - **Archivo:** `src/presentation/components/Popup/PopupContent/PopupContent.tsx`
+  - **AC ref:** AC-10 (toggle visible en pestaña Funcionalidades), AC-11, AC-12
+  - **Cambios:** desestructurar `selectionTranslator` de `useFeaturesStatus`; añadir `<ExtensionToggle>` con `featureName="Traductor de Selección"` y `tooltipText` descriptivo
+  - **Done cuando:** test de `PopupContent` verifica que el toggle "Traductor de Selección" está presente en el DOM
+  - **Bloqueado por:** UI-007
+
+---
+
+## Cobertura de Criterios de Aceptación
+
+| AC     | Descripción (resumen)                         | Tareas que lo implementan        |
+| ------ | --------------------------------------------- | -------------------------------- |
+| AC-01  | Burbuja aparece con selección ≥3 chars        | UI-002, UI-004, UI-006           |
+| AC-02  | Burbuja NO aparece con <3 chars / whitespace  | UI-002, UI-004                   |
+| AC-03  | Hover → tooltip con traducción                | APP-001, APP-002, UI-003, UI-005 |
+| AC-04  | Detección automática idioma fuente            | APP-001                          |
+| AC-05  | Sin bloqueo si source === target              | APP-001                          |
+| AC-06  | Dropdown idioma destino en tooltip            | UI-005                           |
+| AC-07  | Cambio idioma re-traduce                      | UI-003, UI-005                   |
+| AC-08  | Idioma destino persiste (reusa storage existente) | UI-005                       |
+| AC-09  | Botón copiar con feedback visual              | UI-005                           |
+| AC-10  | Toggle visible en popup / pestaña Funcionalidades | UI-007, UI-008               |
+| AC-11  | Desactivar oculta burbuja                     | UI-001, UI-006, UI-007, UI-008   |
+| AC-12  | Activar muestra burbuja                       | UI-001, UI-006, UI-007, UI-008   |
+
+**Edge cases cubiertos:**
+- Edge #1 (whitespace) → UI-002
+- Edge #2 (modelo descargando — spinner sin porcentaje per ADR-001) → UI-005
+- Edge #3 (descarga falla, retry) → UI-003, UI-005
+- Edge #4 (API no disponible) → APP-001, UI-005
+- Edge #5 (nueva selección con tooltip abierto) → UI-006
+- Edge #6 (scroll cierra tooltip) → UI-002
+- Edge #7 (selección en input/textarea) → cubierto por comportamiento estándar del DOM
+- Edge #8 (CSP) → cubierto por Shadow DOM en entrypoint (UI-006)
+
+---
+
+## Orden de implementación (DAG)
+
+```
+CONFIG-001
+  ├── APP-001
+  │     └── APP-002
+  │           └── UI-003
+  │                 └── UI-005
+  │                       └── UI-006 ←─────────────┐
+  ├── UI-001                                        │
+  │     ├── UI-006 ◄──────────────────────────────┤
+  │     ├── UI-007                                  │
+  │           └── UI-008                            │
+  └── (UI-002 y UI-004 sin bloqueo externo)         │
+        ├── UI-002 ─────────────────────────► UI-006
+        └── UI-004 ─────────────────────────► UI-006
+```
+
+**Recomendación de inicio:**
+1. CONFIG-001 (desbloquea todo)
+2. En paralelo: APP-001 + UI-001 + UI-002 + UI-004
+3. APP-002 → UI-003 → UI-005 → UI-006
+4. UI-007 → UI-008
+
+---
+
+## Seguimiento
+
+| Tarea     | Descripción                                        | Estado       | PR / Commit | Notas |
+| --------- | -------------------------------------------------- | ------------ | ----------- | ----- |
+| CONFIG-001 | Agregar storage key + message type a globalStrings | ✅ done | src/config/utils/globalStrings.ts | —     |
+| APP-001   | `handleSelectionMessage` en backgroundController   | ✅ done | src/presentation/entrypoints/background/controller.ts | —     |
+| APP-002   | Case `SELECTION_MESSAGE` en background/index.ts    | ⬜ pendiente | —           | —     |
+| UI-001    | Hook `useSelectionTranslatorStatus`                | ⬜ pendiente | —           | —     |
+| UI-002    | Hook `useTextSelection`                            | ⬜ pendiente | —           | —     |
+| UI-003    | Hook `useSelectionTranslation`                     | ⬜ pendiente | —           | —     |
+| UI-004    | Componente `SelectionBubble`                       | ⬜ pendiente | —           | —     |
+| UI-005    | Componente `SelectionTooltip`                      | ⬜ pendiente | —           | —     |
+| UI-006    | Componente `SelectionLocalTranslator` + entrypoint | ⬜ pendiente | —           | —     |
+| UI-007    | `selectionTranslator` en `useFeaturesStatus`       | ⬜ pendiente | —           | —     |
+| UI-008    | `ExtensionToggle` en `PopupContent`                | ⬜ pendiente | —           | —     |
+
+**Leyenda:** ⬜ pendiente | 🔄 en progreso | ✅ done | 🚫 bloqueado | ⏭️ descartado

--- a/src/config/utils/globalStrings.ts
+++ b/src/config/utils/globalStrings.ts
@@ -34,6 +34,8 @@ export const GLOBAL_STRINGS = {
     SUBTITLE_BG_COLOR: "subtitleBgColor",
     /** Key for storing selection translator active state in local storage */
     SELECTION_TRANSLATOR_IS_ACTIVE: "selectionTranslatorIsActive",
+    /** Key for storing selection translator target language in local storage */
+    SELECTION_TRANSLATOR_TARGET_LANGUAGE: "selectionTranslatorTargetLanguage",
   },
   SPEECH_TO_TRANSLATE_CONFIG: {
     /** Source language for speech recognition — always Spanish */

--- a/src/config/utils/globalStrings.ts
+++ b/src/config/utils/globalStrings.ts
@@ -32,6 +32,8 @@ export const GLOBAL_STRINGS = {
     SUBTITLE_FONT_COLOR: "subtitleFontColor",
     /** Key for storing the subtitle display background color in local storage */
     SUBTITLE_BG_COLOR: "subtitleBgColor",
+    /** Key for storing selection translator active state in local storage */
+    SELECTION_TRANSLATOR_IS_ACTIVE: "selectionTranslatorIsActive",
   },
   SPEECH_TO_TRANSLATE_CONFIG: {
     /** Source language for speech recognition — always Spanish */
@@ -47,6 +49,7 @@ export const GLOBAL_STRINGS = {
     CHAT_MESSAGE: "CHAT_MESSAGE",
     INPUT_MESSAGE: "INPUT_MESSAGE",
     CHECK_EXT_UPLOAD: "CHECK_EXT_UPLOAD",
+    SELECTION_MESSAGE: "SELECTION_MESSAGE",
   },
   APP_INFORMATION: {
     APP_NAME: "Redna Models",

--- a/src/presentation/components/LanguageSelector/LanguageSelector.tsx
+++ b/src/presentation/components/LanguageSelector/LanguageSelector.tsx
@@ -1,88 +1,20 @@
 import { useState, useEffect } from "react";
-import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "../ui/command";
-import languagesSupported from "./languagesSupported";
-import { LANGUAGE_SELECTOR } from "./languageSelector.strings.json";
-
-import { cn } from "~@/presentation/lib/utils";
-import { Check, ChevronsUpDown } from "lucide-react";
 import { useLocalTranslatorTargetLanguage } from "~@/presentation/hooks/useLocalTranslatorTargetLanguage/useLocalTranslatorTargetLanguage";
-import { TooltipTriggerAsChild } from "../ui/own/tooltip-trigger-aschild";
+import { LanguageSelectorControlled } from "./LanguageSelectorControlled";
 
 export const LanguageSelector = () => {
   const { setItem, getItem, watchItem } = useLocalTranslatorTargetLanguage();
-  const [open, setOpen] = useState(false);
   const [value, setValue] = useState<string>("");
 
-  const init = async () => {
-    const currentValue = await getItem();
-    setValue(currentValue);
-  };
-
   useEffect(() => {
-    init();
+    getItem().then(setValue);
   }, []);
 
-  watchItem((newValue) => {
-    setValue(newValue);
-  });
+  watchItem(setValue);
 
-  const handleSelect = async (currentValue: string) => {
-    await setItem(currentValue);
-    setOpen(false);
+  const handleChange = async (lang: string) => {
+    await setItem(lang);
   };
 
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger>
-        <TooltipTriggerAsChild tooltipText="Selecciona el idioma al que deseas traducir tus mensajes">
-          <div
-            aria-expanded={open}
-            className="flex items-center justify-between gap-2 rounded-sm border border-accent bg-ew-star-color px-3 py-2 transition-colors duration-500 ease-in-out hover:cursor-pointer hover:bg-background"
-          >
-            {value
-              ? languagesSupported.find((language) => language.value === value)
-                  ?.label
-              : LANGUAGE_SELECTOR.SELECT_LANGUAGE}
-            <ChevronsUpDown className="size-4" />
-          </div>
-        </TooltipTriggerAsChild>
-      </PopoverTrigger>
-      <PopoverContent className="w-52 p-0">
-        <Command>
-          <CommandInput
-            placeholder={LANGUAGE_SELECTOR.SEARCH_PLACEHOLDER}
-            className="h-9"
-          />
-          <CommandList>
-            <CommandEmpty>{LANGUAGE_SELECTOR.NO_LANGUAGE_FOUND}</CommandEmpty>
-            <CommandGroup>
-              {languagesSupported.map((language) => (
-                <CommandItem
-                  key={language.value}
-                  value={language.value}
-                  onSelect={handleSelect}
-                >
-                  {language.label}
-                  <Check
-                    className={cn(
-                      "ml-auto",
-                      value === language.value ? "opacity-100" : "opacity-0",
-                    )}
-                  />
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
-  );
+  return <LanguageSelectorControlled value={value} onChange={handleChange} />;
 };

--- a/src/presentation/components/LanguageSelector/LanguageSelectorControlled.tsx
+++ b/src/presentation/components/LanguageSelector/LanguageSelectorControlled.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "../ui/command";
+import languagesSupported from "./languagesSupported";
+import { LANGUAGE_SELECTOR } from "./languageSelector.strings.json";
+import { cn } from "~@/presentation/lib/utils";
+import { Check, ChevronsUpDown } from "lucide-react";
+import { TooltipTriggerAsChild } from "../ui/own/tooltip-trigger-aschild";
+
+export interface LanguageSelectorControlledProps {
+  value: string;
+  onChange: (lang: string) => void;
+  tooltipText?: string;
+}
+
+export const LanguageSelectorControlled = ({
+  value,
+  onChange,
+  tooltipText = "Selecciona el idioma al que deseas traducir tus mensajes",
+}: LanguageSelectorControlledProps) => {
+  const [open, setOpen] = useState(false);
+
+  const handleSelect = (selected: string) => {
+    onChange(selected);
+    setOpen(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger>
+        <TooltipTriggerAsChild tooltipText={tooltipText}>
+          <div
+            aria-expanded={open}
+            className="flex items-center justify-between gap-2 rounded-sm border border-accent bg-ew-star-color px-3 py-2 transition-colors duration-500 ease-in-out hover:cursor-pointer hover:bg-background"
+          >
+            {value
+              ? languagesSupported.find((language) => language.value === value)?.label
+              : LANGUAGE_SELECTOR.SELECT_LANGUAGE}
+            <ChevronsUpDown className="size-4" />
+          </div>
+        </TooltipTriggerAsChild>
+      </PopoverTrigger>
+      <PopoverContent className="w-52 p-0">
+        <Command>
+          <CommandInput
+            placeholder={LANGUAGE_SELECTOR.SEARCH_PLACEHOLDER}
+            className="h-9"
+          />
+          <CommandList>
+            <CommandEmpty>{LANGUAGE_SELECTOR.NO_LANGUAGE_FOUND}</CommandEmpty>
+            <CommandGroup>
+              {languagesSupported.map((language) => (
+                <CommandItem
+                  key={language.value}
+                  value={language.value}
+                  onSelect={handleSelect}
+                >
+                  {language.label}
+                  <Check
+                    className={cn(
+                      "ml-auto",
+                      value === language.value ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/src/presentation/components/LanguageSelector/__test__/LanguageSelectorControlled.test.tsx
+++ b/src/presentation/components/LanguageSelector/__test__/LanguageSelectorControlled.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import React from "react";
+
+vi.mock("../../ui/own/tooltip-trigger-aschild", () => ({
+  TooltipTriggerAsChild: ({ children }: any) => children,
+}));
+
+vi.mock("../../ui/popover", () => ({
+  Popover: ({ children, open, onOpenChange }: any) =>
+    React.createElement(
+      "div",
+      null,
+      React.Children.map(children, (child: any) =>
+        React.cloneElement(child, { open, onOpenChange }),
+      ),
+    ),
+  PopoverTrigger: ({ children, open, onOpenChange }: any) =>
+    React.createElement(
+      "button",
+      { "data-testid": "language-trigger", onClick: () => onOpenChange?.(!open) },
+      children,
+    ),
+  PopoverContent: ({ children, open }: any) =>
+    open
+      ? React.createElement("div", { "data-testid": "language-content" }, children)
+      : null,
+}));
+
+vi.mock("../../ui/command", () => ({
+  Command: ({ children }: any) => React.createElement("div", null, children),
+  CommandList: ({ children }: any) => React.createElement("div", null, children),
+  CommandGroup: ({ children }: any) => React.createElement("div", null, children),
+  CommandEmpty: ({ children }: any) =>
+    React.createElement("div", { "data-testid": "cmd-empty" }, children),
+  CommandInput: ({ placeholder }: any) => React.createElement("input", { placeholder }),
+  CommandItem: ({ children, value, onSelect }: any) =>
+    React.createElement("div", { role: "option", onClick: () => onSelect?.(value) }, children),
+}));
+
+import { LanguageSelectorControlled } from "../LanguageSelectorControlled";
+
+describe("LanguageSelectorControlled", () => {
+  const onChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows placeholder when value is empty", () => {
+    render(<LanguageSelectorControlled value="" onChange={onChange} />);
+    expect(screen.getByText("Selecciona un lenguaje...")).toBeInTheDocument();
+  });
+
+  it("shows language label for given value", () => {
+    render(<LanguageSelectorControlled value="es" onChange={onChange} />);
+    expect(screen.getByText("Español")).toBeInTheDocument();
+  });
+
+  it("opens language list on trigger click", () => {
+    render(<LanguageSelectorControlled value="en" onChange={onChange} />);
+    fireEvent.click(screen.getByTestId("language-trigger"));
+    expect(screen.getByTestId("language-content")).toBeInTheDocument();
+  });
+
+  it("calls onChange with selected language and closes list", async () => {
+    render(<LanguageSelectorControlled value="en" onChange={onChange} />);
+    fireEvent.click(screen.getByTestId("language-trigger"));
+    fireEvent.click(screen.getByRole("option", { name: "Español" }));
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith("es");
+      expect(screen.queryByTestId("language-content")).not.toBeInTheDocument();
+    });
+  });
+
+  it("accepts custom tooltipText prop", () => {
+    render(
+      <LanguageSelectorControlled
+        value="en"
+        onChange={onChange}
+        tooltipText="Custom tooltip"
+      />,
+    );
+    expect(screen.getByTestId("language-trigger")).toBeInTheDocument();
+  });
+});

--- a/src/presentation/components/Popup/PopupContent/PopupContent.tsx
+++ b/src/presentation/components/Popup/PopupContent/PopupContent.tsx
@@ -21,7 +21,8 @@ import {
 import { ExtensionToggle } from "../ExtensionToggle/ExtensionToggle";
 
 export const PopupContent = () => {
-  const { translator, quickMessages, quickMenu, speechToTranslate } = useFeaturesStatus();
+  const { translator, quickMessages, quickMenu, speechToTranslate, selectionTranslator } =
+    useFeaturesStatus();
 
   return (
     <CardContent className="px-4">
@@ -75,6 +76,13 @@ export const PopupContent = () => {
               orientation="horizontal"
               featureName="Speech to Translate"
               tooltipText="Traduce tu voz en tiempo real y muestra subtítulos para capturar en OBS"
+            />
+            <ExtensionToggle
+              isEnabled={selectionTranslator.isEnabled}
+              onToggle={selectionTranslator.toggle}
+              orientation="horizontal"
+              featureName="Traductor de Selección"
+              tooltipText="Traduce el texto que selecciones en cualquier página web"
             />
           </div>
         </TabsContent>

--- a/src/presentation/components/Popup/PopupContent/__tests__/PopupContent.test.tsx
+++ b/src/presentation/components/Popup/PopupContent/__tests__/PopupContent.test.tsx
@@ -10,6 +10,7 @@ vi.mock("~@/presentation/hooks/useFeaturesStatus/useFeaturesStatus", () => ({
     quickMessages: { isEnabled: true, toggle: vi.fn() },
     quickMenu: { isEnabled: true, toggle: vi.fn() },
     speechToTranslate: { isEnabled: false, toggle: vi.fn() },
+    selectionTranslator: { isEnabled: true, toggle: vi.fn() },
     isInitialized: true,
   }),
 }));
@@ -30,8 +31,8 @@ vi.mock("../../QuickMessageOperations/QuickMessageOperations", () => ({
 }));
 
 vi.mock("../../ExtensionToggle/ExtensionToggle", () => ({
-  ExtensionToggle: () => (
-    <div data-testid="extension-toggle">ExtensionToggle</div>
+  ExtensionToggle: ({ featureName }: { featureName: string }) => (
+    <div data-testid="extension-toggle">{featureName}</div>
   ),
 }));
 
@@ -67,6 +68,11 @@ describe("PopupContent Component", () => {
     // QuickMessages tab is default
     expect(screen.getByTestId("quick-message-operations")).toBeInTheDocument();
     expect(screen.getByTestId("quick-messages-list")).toBeInTheDocument();
+  });
+
+  it("should render Traductor de Selección toggle in features tab", () => {
+    render(<PopupContent />);
+    expect(screen.getByText("Traductor de Selección")).toBeInTheDocument();
   });
 
   it("should have correct layout structure for QuickMessages tab", () => {

--- a/src/presentation/components/SelectionLocalTranslator/SelectionBubble/SelectionBubble.tsx
+++ b/src/presentation/components/SelectionLocalTranslator/SelectionBubble/SelectionBubble.tsx
@@ -7,15 +7,15 @@ export interface SelectionBubbleProps {
 }
 
 export const SelectionBubble = ({ rect, onHover }: SelectionBubbleProps) => {
-  const top = rect.top - 36;
-  const left = rect.left + rect.width / 2 - 14;
+  const top = rect.top + window.scrollY - 36;
+  const left = rect.left + window.scrollX + rect.width / 2 - 14;
 
   return (
     <div>
       <Button
         data-testid="selection-bubble-button"
         aria-label="Translate selection"
-        className="pointer-events-auto fixed z-1000000 flex h-7 w-7 cursor-pointer items-center justify-center rounded-full bg-secondary shadow-lg"
+        className="pointer-events-auto absolute z-1000000 flex h-7 w-7 cursor-pointer items-center justify-center rounded-full bg-secondary shadow-lg"
         style={{
           top: `${top}px`,
           left: `${left}px`,

--- a/src/presentation/components/SelectionLocalTranslator/SelectionBubble/SelectionBubble.tsx
+++ b/src/presentation/components/SelectionLocalTranslator/SelectionBubble/SelectionBubble.tsx
@@ -1,0 +1,29 @@
+import { EwLogo } from "~@/presentation/components/EwLogo/EwLogo";
+import { Button } from "../../ui/button";
+
+export interface SelectionBubbleProps {
+  rect: DOMRect;
+  onHover: () => void;
+}
+
+export const SelectionBubble = ({ rect, onHover }: SelectionBubbleProps) => {
+  const top = rect.top - 36;
+  const left = rect.left + rect.width / 2 - 14;
+
+  return (
+    <div>
+      <Button
+        data-testid="selection-bubble-button"
+        aria-label="Translate selection"
+        className="pointer-events-auto fixed z-1000000 flex h-7 w-7 cursor-pointer items-center justify-center rounded-full bg-secondary shadow-lg"
+        style={{
+          top: `${top}px`,
+          left: `${left}px`,
+        }}
+        onMouseEnter={onHover}
+      >
+        <EwLogo className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+};

--- a/src/presentation/components/SelectionLocalTranslator/SelectionBubble/__test__/SelectionBubble.test.tsx
+++ b/src/presentation/components/SelectionLocalTranslator/SelectionBubble/__test__/SelectionBubble.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SelectionBubble } from "../SelectionBubble";
+
+const makeRect = (overrides: Partial<DOMRect> = {}): DOMRect => ({
+  top: 100,
+  left: 50,
+  width: 200,
+  height: 20,
+  right: 250,
+  bottom: 120,
+  x: 50,
+  y: 100,
+  toJSON: () => ({}),
+  ...overrides,
+});
+
+describe("SelectionBubble", () => {
+  it("renders with valid rect", () => {
+    render(<SelectionBubble rect={makeRect()} onHover={vi.fn()} />);
+    expect(screen.getByTestId("selection-bubble-button")).toBeInTheDocument();
+  });
+
+  it("positions bubble above center of selection", () => {
+    const rect = makeRect({ top: 200, left: 100, width: 300 });
+    render(<SelectionBubble rect={rect} onHover={vi.fn()} />);
+    const bubble = screen.getByTestId("selection-bubble-button");
+    expect(bubble.style.top).toBe("164px"); // 200 - 36
+    expect(bubble.style.left).toBe("236px"); // 100 + 300/2 - 14
+  });
+
+  it("calls onHover on mouseenter", () => {
+    const onHover = vi.fn();
+    render(<SelectionBubble rect={makeRect()} onHover={onHover} />);
+    fireEvent.mouseEnter(screen.getByTestId("selection-bubble-button"));
+    expect(onHover).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onHover without mouseenter", () => {
+    const onHover = vi.fn();
+    render(<SelectionBubble rect={makeRect()} onHover={onHover} />);
+    expect(onHover).not.toHaveBeenCalled();
+  });
+
+  it("renders EwLogo inside bubble", () => {
+    render(<SelectionBubble rect={makeRect()} onHover={vi.fn()} />);
+    const bubble = screen.getByTestId("selection-bubble-button");
+    expect(bubble.querySelector("svg")).not.toBeNull();
+  });
+});

--- a/src/presentation/components/SelectionLocalTranslator/SelectionLocalTranslator.tsx
+++ b/src/presentation/components/SelectionLocalTranslator/SelectionLocalTranslator.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useSelectionTranslatorStatus } from "~@/presentation/hooks/useSelectionTranslatorStatus/useSelectionTranslatorStatus";
-import { useLocalTranslatorTargetLanguage } from "~@/presentation/hooks/useLocalTranslatorTargetLanguage/useLocalTranslatorTargetLanguage";
+import { useSelectionTranslatorTargetLanguage } from "~@/presentation/hooks/useSelectionTranslatorTargetLanguage/useSelectionTranslatorTargetLanguage";
 import { useTextSelection } from "./hooks/useTextSelection";
 import { useSelectionTranslation } from "./hooks/useSelectionTranslation";
 import { SelectionBubble } from "./SelectionBubble/SelectionBubble";
@@ -8,7 +8,7 @@ import { SelectionTooltip } from "./SelectionTooltip/SelectionTooltip";
 
 export const SelectionLocalTranslator = () => {
   const selectionTranslatorStatus = useSelectionTranslatorStatus();
-  const targetLanguageStorage = useLocalTranslatorTargetLanguage();
+  const targetLanguageStorage = useSelectionTranslatorTargetLanguage();
   const { selection } = useTextSelection();
   const { status, translatedText, sourceLanguage, errorMessage, translate, reset } =
     useSelectionTranslation();

--- a/src/presentation/components/SelectionLocalTranslator/SelectionLocalTranslator.tsx
+++ b/src/presentation/components/SelectionLocalTranslator/SelectionLocalTranslator.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useState } from "react";
+import { useSelectionTranslatorStatus } from "~@/presentation/hooks/useSelectionTranslatorStatus/useSelectionTranslatorStatus";
+import { useLocalTranslatorTargetLanguage } from "~@/presentation/hooks/useLocalTranslatorTargetLanguage/useLocalTranslatorTargetLanguage";
+import { useTextSelection } from "./hooks/useTextSelection";
+import { useSelectionTranslation } from "./hooks/useSelectionTranslation";
+import { SelectionBubble } from "./SelectionBubble/SelectionBubble";
+import { SelectionTooltip } from "./SelectionTooltip/SelectionTooltip";
+
+export const SelectionLocalTranslator = () => {
+  const selectionTranslatorStatus = useSelectionTranslatorStatus();
+  const targetLanguageStorage = useLocalTranslatorTargetLanguage();
+  const { selection } = useTextSelection();
+  const { status, translatedText, sourceLanguage, errorMessage, translate, reset } =
+    useSelectionTranslation();
+
+  const [isEnabled, setIsEnabled] = useState(false);
+  const [targetLanguage, setTargetLanguage] = useState("en");
+  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
+
+  useEffect(() => {
+    selectionTranslatorStatus.getItem().then(setIsEnabled);
+    targetLanguageStorage.getItem().then((val) => setTargetLanguage(val ?? "en"));
+  }, []);
+
+  selectionTranslatorStatus.watchItem(setIsEnabled);
+  targetLanguageStorage.watchItem((val) => setTargetLanguage(val ?? "en"));
+
+  const prevSelectionText = useRef<string | null>(null);
+  useEffect(() => {
+    const newText = selection?.text ?? null;
+    if (newText !== prevSelectionText.current) {
+      prevSelectionText.current = newText;
+      setIsTooltipOpen(false);
+      reset();
+    }
+  }, [selection, reset]);
+
+  if (!isEnabled) return null;
+
+  const handleBubbleHover = () => {
+    setIsTooltipOpen(true);
+    if (selection) {
+      translate(selection.text, targetLanguage);
+    }
+  };
+
+  const handleLanguageChange = async (lang: string) => {
+    await targetLanguageStorage.setItem(lang);
+    if (selection) {
+      translate(selection.text, lang);
+    }
+  };
+
+  const handleRetry = () => {
+    if (selection) {
+      translate(selection.text, targetLanguage);
+    }
+  };
+
+  return (
+    <>
+      {selection && <SelectionBubble rect={selection.rect} onHover={handleBubbleHover} />}
+      {isTooltipOpen && selection && (
+        <div
+          style={{
+            position: "fixed",
+            top: `${selection.rect.bottom + 8}px`,
+            left: `${selection.rect.left}px`,
+            zIndex: 1000000,
+          }}
+        >
+          <SelectionTooltip
+            status={status}
+            translatedText={translatedText}
+            sourceLanguage={sourceLanguage}
+            errorMessage={errorMessage}
+            onRetry={handleRetry}
+            onLanguageChange={handleLanguageChange}
+            targetLanguage={targetLanguage}
+          />
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/presentation/components/SelectionLocalTranslator/SelectionLocalTranslator.tsx
+++ b/src/presentation/components/SelectionLocalTranslator/SelectionLocalTranslator.tsx
@@ -63,9 +63,9 @@ export const SelectionLocalTranslator = () => {
       {isTooltipOpen && selection && (
         <div
           style={{
-            position: "fixed",
-            top: `${selection.rect.bottom + 8}px`,
-            left: `${selection.rect.left}px`,
+            position: "absolute",
+            top: `${selection.rect.bottom + window.scrollY + 8}px`,
+            left: `${selection.rect.left + window.scrollX}px`,
             zIndex: 1000000,
           }}
         >

--- a/src/presentation/components/SelectionLocalTranslator/SelectionTooltip/SelectionTooltip.tsx
+++ b/src/presentation/components/SelectionLocalTranslator/SelectionTooltip/SelectionTooltip.tsx
@@ -1,0 +1,101 @@
+import { useState } from "react";
+import { Copy, Check, RotateCcw, Loader2 } from "lucide-react";
+import { Button } from "~@/presentation/components/ui/button";
+import languagesSupported from "~@/presentation/components/LanguageSelector/languagesSupported";
+import { LanguageSelectorControlled } from "~@/presentation/components/LanguageSelector/LanguageSelectorControlled";
+import { TranslationStatus } from "../hooks/useSelectionTranslation";
+
+export interface SelectionTooltipProps {
+  status: TranslationStatus;
+  translatedText: string | null;
+  sourceLanguage: string | null;
+  errorMessage?: string;
+  onRetry: () => void;
+  onLanguageChange: (lang: string) => void;
+  targetLanguage: string;
+}
+
+export const SelectionTooltip = ({
+  status,
+  translatedText,
+  sourceLanguage,
+  errorMessage,
+  onRetry,
+  onLanguageChange,
+  targetLanguage,
+}: SelectionTooltipProps) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (!translatedText) return;
+    await navigator.clipboard.writeText(translatedText);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const sourceLangLabel = sourceLanguage
+    ? (languagesSupported.find((l) => l.value === sourceLanguage)?.label ?? sourceLanguage)
+    : null;
+
+  return (
+    <div
+      data-testid="selection-tooltip"
+      className="flex min-w-48 max-w-xs flex-col gap-2 rounded-lg border border-ew-star-color bg-background p-3 shadow-lg"
+    >
+      <LanguageSelectorControlled
+        value={targetLanguage}
+        onChange={onLanguageChange}
+        tooltipText="Selecciona el idioma al que deseas traducir la selección"
+      />
+
+      {status === "translating" && (
+        <div className="flex items-center justify-center py-2" data-testid="spinner">
+          <Loader2 className="h-5 w-5 animate-spin" />
+        </div>
+      )}
+
+      {status === "done" && (
+        <div className="flex flex-col gap-1">
+          <p data-testid="translated-text" className="text-sm">
+            {translatedText}
+          </p>
+          {sourceLangLabel && (
+            <span data-testid="source-language" className="text-xs text-muted-foreground">
+              Desde: {sourceLangLabel}
+            </span>
+          )}
+          <Button
+            data-testid="copy-button"
+            size="sm"
+            variant="outline"
+            className="mt-1 self-end"
+            onClick={handleCopy}
+          >
+            {copied ? (
+              <Check className="h-3 w-3" data-testid="check-icon" />
+            ) : (
+              <Copy className="h-3 w-3" data-testid="copy-icon" />
+            )}
+          </Button>
+        </div>
+      )}
+
+      {status === "error" && (
+        <div className="flex flex-col gap-1">
+          <p data-testid="error-message" className="text-sm text-destructive">
+            {errorMessage ?? "Error al traducir"}
+          </p>
+          <Button
+            data-testid="retry-button"
+            size="sm"
+            variant="outline"
+            onClick={onRetry}
+          >
+            <RotateCcw className="mr-1 h-3 w-3" />
+            Reintentar
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/presentation/components/SelectionLocalTranslator/SelectionTooltip/SelectionTooltip.tsx
+++ b/src/presentation/components/SelectionLocalTranslator/SelectionTooltip/SelectionTooltip.tsx
@@ -2,8 +2,8 @@ import { useState } from "react";
 import { Copy, Check, RotateCcw, Loader2 } from "lucide-react";
 import { Button } from "~@/presentation/components/ui/button";
 import languagesSupported from "~@/presentation/components/LanguageSelector/languagesSupported";
-import { LanguageSelectorControlled } from "~@/presentation/components/LanguageSelector/LanguageSelectorControlled";
 import { TranslationStatus } from "../hooks/useSelectionTranslation";
+import { Label } from "../../ui/label";
 
 export interface SelectionTooltipProps {
   status: TranslationStatus;
@@ -34,49 +34,78 @@ export const SelectionTooltip = ({
   };
 
   const sourceLangLabel = sourceLanguage
-    ? (languagesSupported.find((l) => l.value === sourceLanguage)?.label ?? sourceLanguage)
+    ? (languagesSupported.find((l) => l.value === sourceLanguage)?.label ??
+      sourceLanguage)
     : null;
 
   return (
     <div
       data-testid="selection-tooltip"
-      className="flex min-w-48 max-w-xs flex-col gap-2 rounded-lg border border-ew-star-color bg-background p-3 shadow-lg"
+      className="flex max-w-xs min-w-48 flex-col gap-2 rounded-lg border border-ew-star-color bg-background p-3 shadow-lg"
     >
-      <LanguageSelectorControlled
-        value={targetLanguage}
-        onChange={onLanguageChange}
-        tooltipText="Selecciona el idioma al que deseas traducir la selección"
-      />
-
       {status === "translating" && (
-        <div className="flex items-center justify-center py-2" data-testid="spinner">
+        <div
+          className="flex items-center justify-center py-2"
+          data-testid="spinner"
+        >
           <Loader2 className="h-5 w-5 animate-spin" />
         </div>
       )}
 
       {status === "done" && (
         <div className="flex flex-col gap-1">
-          <p data-testid="translated-text" className="text-sm">
-            {translatedText}
-          </p>
           {sourceLangLabel && (
-            <span data-testid="source-language" className="text-xs text-muted-foreground">
+            <span
+              data-testid="source-language"
+              className="text-xs text-muted-foreground"
+            >
               Desde: {sourceLangLabel}
             </span>
           )}
-          <Button
-            data-testid="copy-button"
-            size="sm"
-            variant="outline"
-            className="mt-1 self-end"
-            onClick={handleCopy}
+
+          <p
+            data-testid="translated-text"
+            className="w-full rounded-md border bg-background p-2 text-sm"
           >
-            {copied ? (
-              <Check className="h-3 w-3" data-testid="check-icon" />
-            ) : (
-              <Copy className="h-3 w-3" data-testid="copy-icon" />
-            )}
-          </Button>
+            {translatedText}
+          </p>
+
+          <div className="flex items-center justify-between gap-2">
+            <div>
+              <Label
+                htmlFor="language"
+                className="text-xs text-muted-foreground"
+              >
+                Traducido a:{" "}
+              </Label>
+              <select
+                name="language"
+                className="rounded-md bg-primary py-1 text-primary-foreground"
+                value={targetLanguage}
+                onChange={(e) => onLanguageChange(e.target.value)}
+              >
+                {languagesSupported.map((lang) => (
+                  <option key={lang.value} value={lang.value}>
+                    {lang.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <Button
+              data-testid="copy-button"
+              size="sm"
+              variant="outline"
+              className="mt-1 self-end"
+              onClick={handleCopy}
+            >
+              {copied ? (
+                <Check className="h-3 w-3" data-testid="check-icon" />
+              ) : (
+                <Copy className="h-3 w-3" data-testid="copy-icon" />
+              )}
+            </Button>
+          </div>
         </div>
       )}
 

--- a/src/presentation/components/SelectionLocalTranslator/SelectionTooltip/__test__/SelectionTooltip.test.tsx
+++ b/src/presentation/components/SelectionLocalTranslator/SelectionTooltip/__test__/SelectionTooltip.test.tsx
@@ -2,21 +2,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { SelectionTooltip, SelectionTooltipProps } from "../SelectionTooltip";
 
-vi.mock(
-  "~@/presentation/components/LanguageSelector/LanguageSelectorControlled",
-  () => ({
-    LanguageSelectorControlled: ({ value, onChange }: { value: string; onChange: (l: string) => void }) => (
-      <button
-        data-testid="language-selector-controlled"
-        data-value={value}
-        onClick={() => onChange("fr")}
-      >
-        {value}
-      </button>
-    ),
-  }),
-);
-
 const defaultProps: SelectionTooltipProps = {
   status: "idle",
   translatedText: null,
@@ -121,17 +106,31 @@ describe("SelectionTooltip", () => {
     vi.useRealTimers();
   });
 
-  it("renders LanguageSelectorControlled with current targetLanguage", () => {
-    render(<SelectionTooltip {...defaultProps} targetLanguage="es" status="idle" />);
-    expect(screen.getByTestId("language-selector-controlled")).toHaveAttribute("data-value", "es");
+  it("renders language select with current targetLanguage", () => {
+    render(
+      <SelectionTooltip
+        {...defaultProps}
+        status="done"
+        translatedText="Hello"
+        sourceLanguage="es"
+        targetLanguage="es"
+      />,
+    );
+    expect(screen.getByRole("combobox")).toHaveValue("es");
   });
 
-  it("calls onLanguageChange when LanguageSelectorControlled fires onChange", () => {
+  it("calls onLanguageChange when select value changes", () => {
     const onLanguageChange = vi.fn();
     render(
-      <SelectionTooltip {...defaultProps} status="idle" onLanguageChange={onLanguageChange} />,
+      <SelectionTooltip
+        {...defaultProps}
+        status="done"
+        translatedText="Hello"
+        sourceLanguage="es"
+        onLanguageChange={onLanguageChange}
+      />,
     );
-    fireEvent.click(screen.getByTestId("language-selector-controlled"));
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "fr" } });
     expect(onLanguageChange).toHaveBeenCalledWith("fr");
   });
 

--- a/src/presentation/components/SelectionLocalTranslator/SelectionTooltip/__test__/SelectionTooltip.test.tsx
+++ b/src/presentation/components/SelectionLocalTranslator/SelectionTooltip/__test__/SelectionTooltip.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { SelectionTooltip, SelectionTooltipProps } from "../SelectionTooltip";
+
+vi.mock(
+  "~@/presentation/components/LanguageSelector/LanguageSelectorControlled",
+  () => ({
+    LanguageSelectorControlled: ({ value, onChange }: { value: string; onChange: (l: string) => void }) => (
+      <button
+        data-testid="language-selector-controlled"
+        data-value={value}
+        onClick={() => onChange("fr")}
+      >
+        {value}
+      </button>
+    ),
+  }),
+);
+
+const defaultProps: SelectionTooltipProps = {
+  status: "idle",
+  translatedText: null,
+  sourceLanguage: null,
+  onRetry: vi.fn(),
+  onLanguageChange: vi.fn(),
+  targetLanguage: "en",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    writable: true,
+  });
+});
+
+describe("SelectionTooltip", () => {
+  it("shows spinner in translating state", () => {
+    render(<SelectionTooltip {...defaultProps} status="translating" />);
+    expect(screen.getByTestId("spinner")).toBeInTheDocument();
+    expect(screen.queryByTestId("translated-text")).toBeNull();
+    expect(screen.queryByTestId("error-message")).toBeNull();
+  });
+
+  it("shows translated text and source language in done state", () => {
+    render(
+      <SelectionTooltip
+        {...defaultProps}
+        status="done"
+        translatedText="Hello world"
+        sourceLanguage="es"
+      />,
+    );
+    expect(screen.getByTestId("translated-text")).toHaveTextContent("Hello world");
+    expect(screen.getByTestId("source-language")).toHaveTextContent("Desde: Español");
+    expect(screen.queryByTestId("spinner")).toBeNull();
+  });
+
+  it("shows error message and retry button in error state", () => {
+    const onRetry = vi.fn();
+    render(
+      <SelectionTooltip
+        {...defaultProps}
+        status="error"
+        errorMessage="Translation unavailable"
+        onRetry={onRetry}
+      />,
+    );
+    expect(screen.getByTestId("error-message")).toHaveTextContent("Translation unavailable");
+    expect(screen.getByTestId("retry-button")).toBeInTheDocument();
+    expect(screen.queryByTestId("spinner")).toBeNull();
+  });
+
+  it("calls onRetry when retry button clicked", () => {
+    const onRetry = vi.fn();
+    render(<SelectionTooltip {...defaultProps} status="error" onRetry={onRetry} />);
+    fireEvent.click(screen.getByTestId("retry-button"));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("copy button writes text to clipboard and shows checkmark", async () => {
+    render(
+      <SelectionTooltip
+        {...defaultProps}
+        status="done"
+        translatedText="Translated!"
+        sourceLanguage="es"
+      />,
+    );
+    expect(screen.getByTestId("copy-icon")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("copy-button"));
+    });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("Translated!");
+    expect(screen.getByTestId("check-icon")).toBeInTheDocument();
+  });
+
+  it("copy button reverts to copy icon after 2 seconds", async () => {
+    vi.useFakeTimers();
+    render(
+      <SelectionTooltip
+        {...defaultProps}
+        status="done"
+        translatedText="Hello"
+        sourceLanguage="es"
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("copy-button"));
+    });
+    expect(screen.getByTestId("check-icon")).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(screen.getByTestId("copy-icon")).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it("renders LanguageSelectorControlled with current targetLanguage", () => {
+    render(<SelectionTooltip {...defaultProps} targetLanguage="es" status="idle" />);
+    expect(screen.getByTestId("language-selector-controlled")).toHaveAttribute("data-value", "es");
+  });
+
+  it("calls onLanguageChange when LanguageSelectorControlled fires onChange", () => {
+    const onLanguageChange = vi.fn();
+    render(
+      <SelectionTooltip {...defaultProps} status="idle" onLanguageChange={onLanguageChange} />,
+    );
+    fireEvent.click(screen.getByTestId("language-selector-controlled"));
+    expect(onLanguageChange).toHaveBeenCalledWith("fr");
+  });
+
+  it("shows fallback error text when errorMessage is undefined", () => {
+    render(<SelectionTooltip {...defaultProps} status="error" />);
+    expect(screen.getByTestId("error-message")).toHaveTextContent("Error al traducir");
+  });
+
+  it("shows source language code when not in languagesSupported", () => {
+    render(
+      <SelectionTooltip
+        {...defaultProps}
+        status="done"
+        translatedText="Test"
+        sourceLanguage="xx"
+      />,
+    );
+    expect(screen.getByTestId("source-language")).toHaveTextContent("Desde: xx");
+  });
+});

--- a/src/presentation/components/SelectionLocalTranslator/__test__/SelectionLocalTranslator.test.tsx
+++ b/src/presentation/components/SelectionLocalTranslator/__test__/SelectionLocalTranslator.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const mockSelectionTranslatorStatus = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  watchItem: vi.fn(),
+};
+const mockTargetLanguageStorage = {
+  getItem: vi.fn(),
+  setItem: vi.fn().mockResolvedValue(undefined),
+  watchItem: vi.fn(),
+};
+let mockSelection: { text: string; rect: DOMRect } | null = null;
+const mockTranslation = {
+  status: "idle" as const,
+  translatedText: null as string | null,
+  sourceLanguage: null as string | null,
+  errorMessage: undefined as string | undefined,
+  translate: vi.fn().mockResolvedValue(undefined),
+  reset: vi.fn(),
+};
+
+vi.mock(
+  "~@/presentation/hooks/useSelectionTranslatorStatus/useSelectionTranslatorStatus",
+  () => ({ useSelectionTranslatorStatus: () => mockSelectionTranslatorStatus }),
+);
+vi.mock(
+  "~@/presentation/hooks/useLocalTranslatorTargetLanguage/useLocalTranslatorTargetLanguage",
+  () => ({ useLocalTranslatorTargetLanguage: () => mockTargetLanguageStorage }),
+);
+vi.mock(
+  "~@/presentation/components/SelectionLocalTranslator/hooks/useTextSelection",
+  () => ({ useTextSelection: () => ({ selection: mockSelection, clearSelection: vi.fn() }) }),
+);
+vi.mock(
+  "~@/presentation/components/SelectionLocalTranslator/hooks/useSelectionTranslation",
+  () => ({ useSelectionTranslation: () => mockTranslation }),
+);
+vi.mock(
+  "~@/presentation/components/SelectionLocalTranslator/SelectionBubble/SelectionBubble",
+  () => ({
+    SelectionBubble: ({ onHover }: { onHover: () => void }) => (
+      <button data-testid="selection-bubble" onMouseEnter={onHover}>
+        bubble
+      </button>
+    ),
+  }),
+);
+vi.mock(
+  "~@/presentation/components/SelectionLocalTranslator/SelectionTooltip/SelectionTooltip",
+  () => ({
+    SelectionTooltip: () => <div data-testid="selection-tooltip">tooltip</div>,
+  }),
+);
+
+import { SelectionLocalTranslator } from "../SelectionLocalTranslator";
+
+const mockRect = {
+  top: 100,
+  left: 200,
+  bottom: 120,
+  right: 400,
+  width: 200,
+  height: 20,
+} as DOMRect;
+
+describe("SelectionLocalTranslator", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSelection = null;
+    mockSelectionTranslatorStatus.getItem.mockResolvedValue(false);
+    mockSelectionTranslatorStatus.watchItem.mockImplementation(vi.fn());
+    mockTargetLanguageStorage.getItem.mockResolvedValue("en");
+    mockTargetLanguageStorage.watchItem.mockImplementation(vi.fn());
+    mockTargetLanguageStorage.setItem.mockResolvedValue(undefined);
+    mockTranslation.translate.mockResolvedValue(undefined);
+    mockTranslation.reset.mockImplementation(vi.fn());
+  });
+
+  it("renders nothing when disabled", async () => {
+    mockSelectionTranslatorStatus.getItem.mockResolvedValue(false);
+    const { container } = render(<SelectionLocalTranslator />);
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it("renders nothing when enabled but no selection", async () => {
+    mockSelectionTranslatorStatus.getItem.mockResolvedValue(true);
+    render(<SelectionLocalTranslator />);
+    await waitFor(() => {
+      expect(screen.queryByTestId("selection-bubble")).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders SelectionBubble when enabled and selection exists", async () => {
+    mockSelectionTranslatorStatus.getItem.mockResolvedValue(true);
+    mockSelection = { text: "hello world", rect: mockRect };
+    render(<SelectionLocalTranslator />);
+    await waitFor(() => {
+      expect(screen.getByTestId("selection-bubble")).toBeInTheDocument();
+    });
+  });
+
+  it("shows SelectionTooltip and calls translate on bubble hover", async () => {
+    mockSelectionTranslatorStatus.getItem.mockResolvedValue(true);
+    mockSelection = { text: "hello world", rect: mockRect };
+    render(<SelectionLocalTranslator />);
+    await waitFor(() => {
+      expect(screen.getByTestId("selection-bubble")).toBeInTheDocument();
+    });
+    fireEvent.mouseEnter(screen.getByTestId("selection-bubble"));
+    expect(screen.getByTestId("selection-tooltip")).toBeInTheDocument();
+    expect(mockTranslation.translate).toHaveBeenCalledWith("hello world", "en");
+  });
+});

--- a/src/presentation/components/SelectionLocalTranslator/hooks/__test__/useSelectionTranslation.test.ts
+++ b/src/presentation/components/SelectionLocalTranslator/hooks/__test__/useSelectionTranslation.test.ts
@@ -1,0 +1,141 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { useSelectionTranslation } from "../useSelectionTranslation";
+
+vi.mock("~@/config/utils/globalStrings", () => ({
+  GLOBAL_STRINGS: {
+    BG_MESSAGE_TYPE: {
+      SELECTION_MESSAGE: "SELECTION_MESSAGE",
+    },
+  },
+}));
+
+const mockSendMessage = vi.fn();
+
+describe("useSelectionTranslation", () => {
+  beforeEach(() => {
+    mockSendMessage.mockReset();
+    vi.spyOn((globalThis as any).browser.runtime, "sendMessage").mockImplementation(mockSendMessage);
+  });
+
+  it("should start in idle state", () => {
+    const { result } = renderHook(() => useSelectionTranslation());
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.translatedText).toBeNull();
+    expect(result.current.sourceLanguage).toBeNull();
+    expect(result.current.errorMessage).toBeUndefined();
+  });
+
+  it("idle → translating → done on successful translation", async () => {
+    const successResponse = {
+      translatedText: "Hola mundo",
+      sourceLanguage: "en",
+    };
+
+    mockSendMessage.mockImplementation((_msg: unknown, callback: (r: typeof successResponse) => void) => {
+      callback(successResponse);
+    });
+
+    const { result } = renderHook(() => useSelectionTranslation());
+
+    await act(async () => {
+      await result.current.translate("Hello world", "es");
+    });
+
+    expect(result.current.status).toBe("done");
+    expect(result.current.translatedText).toBe("Hola mundo");
+    expect(result.current.sourceLanguage).toBe("en");
+    expect(result.current.errorMessage).toBeUndefined();
+  });
+
+  it("idle → translating → error when response is undefined", async () => {
+    mockSendMessage.mockImplementation((_msg: unknown, callback: (r: undefined) => void) => {
+      callback(undefined);
+    });
+
+    const { result } = renderHook(() => useSelectionTranslation());
+
+    await act(async () => {
+      await result.current.translate("Hello world", "es");
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.translatedText).toBeNull();
+    expect(result.current.sourceLanguage).toBeNull();
+    expect(result.current.errorMessage).toBe("Translation unavailable");
+  });
+
+  it("should send correct message to background", async () => {
+    mockSendMessage.mockImplementation((_msg: unknown, callback: (r: undefined) => void) => {
+      callback(undefined);
+    });
+
+    const { result } = renderHook(() => useSelectionTranslation());
+
+    await act(async () => {
+      await result.current.translate("test text", "fr");
+    });
+
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      {
+        type: "SELECTION_MESSAGE",
+        data: "test text",
+        target: "fr",
+      },
+      expect.any(Function),
+    );
+  });
+
+  it("reset returns to idle state", async () => {
+    const successResponse = {
+      translatedText: "Hola",
+      sourceLanguage: "en",
+    };
+
+    mockSendMessage.mockImplementation((_msg: unknown, callback: (r: typeof successResponse) => void) => {
+      callback(successResponse);
+    });
+
+    const { result } = renderHook(() => useSelectionTranslation());
+
+    await act(async () => {
+      await result.current.translate("Hello", "es");
+    });
+
+    expect(result.current.status).toBe("done");
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.translatedText).toBeNull();
+    expect(result.current.sourceLanguage).toBeNull();
+    expect(result.current.errorMessage).toBeUndefined();
+  });
+
+  it("sets status to translating before receiving response", async () => {
+    let capturedStatus = "";
+    let resolveCallback: ((r: { translatedText: string; sourceLanguage: string }) => void) | null = null;
+
+    mockSendMessage.mockImplementation((_msg: unknown, callback: (r: { translatedText: string; sourceLanguage: string }) => void) => {
+      resolveCallback = callback;
+    });
+
+    const { result } = renderHook(() => useSelectionTranslation());
+
+    act(() => {
+      result.current.translate("Hello", "es");
+    });
+
+    capturedStatus = result.current.status;
+    expect(capturedStatus).toBe("translating");
+
+    await act(async () => {
+      resolveCallback!({ translatedText: "Hola", sourceLanguage: "en" });
+    });
+
+    expect(result.current.status).toBe("done");
+  });
+});

--- a/src/presentation/components/SelectionLocalTranslator/hooks/__test__/useTextSelection.test.ts
+++ b/src/presentation/components/SelectionLocalTranslator/hooks/__test__/useTextSelection.test.ts
@@ -1,0 +1,180 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { useTextSelection } from "../useTextSelection";
+
+const mockGetBoundingClientRect = vi.fn(() => ({
+  top: 100,
+  left: 50,
+  width: 200,
+  height: 20,
+  right: 250,
+  bottom: 120,
+  x: 50,
+  y: 100,
+  toJSON: () => ({}),
+}));
+
+const mockRange = {
+  getBoundingClientRect: mockGetBoundingClientRect,
+};
+
+const mockSelection = {
+  rangeCount: 1,
+  toString: vi.fn(),
+  getRangeAt: vi.fn(() => mockRange),
+};
+
+const triggerSelectionChange = () => {
+  document.dispatchEvent(new Event("selectionchange"));
+};
+
+const triggerScroll = () => {
+  document.dispatchEvent(new Event("scroll", { bubbles: true }));
+};
+
+describe("useTextSelection", () => {
+  beforeEach(() => {
+    vi.spyOn(document, "getSelection").mockReturnValue(
+      mockSelection as unknown as Selection,
+    );
+    mockSelection.toString.mockReturnValue("");
+    mockSelection.rangeCount = 1;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should start with null selection", () => {
+    const { result } = renderHook(() => useTextSelection());
+    expect(result.current.selection).toBeNull();
+  });
+
+  it("should set selection when text has ≥3 chars", () => {
+    mockSelection.toString.mockReturnValue("hello world");
+
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      triggerSelectionChange();
+    });
+
+    expect(result.current.selection).not.toBeNull();
+    expect(result.current.selection?.text).toBe("hello world");
+    expect(result.current.selection?.rect).toBeDefined();
+  });
+
+  it("should NOT set selection when text is exactly 2 chars", () => {
+    mockSelection.toString.mockReturnValue("ab");
+
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      triggerSelectionChange();
+    });
+
+    expect(result.current.selection).toBeNull();
+  });
+
+  it("should NOT set selection when text is only whitespace", () => {
+    mockSelection.toString.mockReturnValue("   ");
+
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      triggerSelectionChange();
+    });
+
+    expect(result.current.selection).toBeNull();
+  });
+
+  it("should NOT set selection when text has <3 non-whitespace chars with surrounding spaces", () => {
+    mockSelection.toString.mockReturnValue("  a  ");
+
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      triggerSelectionChange();
+    });
+
+    expect(result.current.selection).toBeNull();
+  });
+
+  it("should clear selection on scroll", () => {
+    mockSelection.toString.mockReturnValue("hello world");
+
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      triggerSelectionChange();
+    });
+
+    expect(result.current.selection).not.toBeNull();
+
+    act(() => {
+      triggerScroll();
+    });
+
+    expect(result.current.selection).toBeNull();
+  });
+
+  it("clearSelection sets selection to null", () => {
+    mockSelection.toString.mockReturnValue("hello world");
+
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      triggerSelectionChange();
+    });
+
+    expect(result.current.selection).not.toBeNull();
+
+    act(() => {
+      result.current.clearSelection();
+    });
+
+    expect(result.current.selection).toBeNull();
+  });
+
+  it("should set selection to null when getSelection returns null", () => {
+    vi.spyOn(document, "getSelection").mockReturnValue(null);
+
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      triggerSelectionChange();
+    });
+
+    expect(result.current.selection).toBeNull();
+  });
+
+  it("should set selection to null when rangeCount is 0", () => {
+    mockSelection.rangeCount = 0;
+
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      triggerSelectionChange();
+    });
+
+    expect(result.current.selection).toBeNull();
+  });
+
+  it("should remove event listeners on unmount", () => {
+    const removeEventListenerSpy = vi.spyOn(document, "removeEventListener");
+
+    const { unmount } = renderHook(() => useTextSelection());
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "selectionchange",
+      expect.any(Function),
+    );
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "scroll",
+      expect.any(Function),
+      true,
+    );
+  });
+});

--- a/src/presentation/components/SelectionLocalTranslator/hooks/__test__/useTextSelection.test.ts
+++ b/src/presentation/components/SelectionLocalTranslator/hooks/__test__/useTextSelection.test.ts
@@ -28,10 +28,6 @@ const triggerSelectionChange = () => {
   document.dispatchEvent(new Event("selectionchange"));
 };
 
-const triggerScroll = () => {
-  document.dispatchEvent(new Event("scroll", { bubbles: true }));
-};
-
 describe("useTextSelection", () => {
   beforeEach(() => {
     vi.spyOn(document, "getSelection").mockReturnValue(
@@ -100,7 +96,7 @@ describe("useTextSelection", () => {
     expect(result.current.selection).toBeNull();
   });
 
-  it("should clear selection on scroll", () => {
+  it("should NOT clear selection on scroll", () => {
     mockSelection.toString.mockReturnValue("hello world");
 
     const { result } = renderHook(() => useTextSelection());
@@ -112,10 +108,10 @@ describe("useTextSelection", () => {
     expect(result.current.selection).not.toBeNull();
 
     act(() => {
-      triggerScroll();
+      document.dispatchEvent(new Event("scroll", { bubbles: true }));
     });
 
-    expect(result.current.selection).toBeNull();
+    expect(result.current.selection).not.toBeNull();
   });
 
   it("clearSelection sets selection to null", () => {
@@ -172,9 +168,12 @@ describe("useTextSelection", () => {
       expect.any(Function),
     );
     expect(removeEventListenerSpy).toHaveBeenCalledWith(
-      "scroll",
+      "mousedown",
       expect.any(Function),
-      true,
+    );
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "mouseup",
+      expect.any(Function),
     );
   });
 });

--- a/src/presentation/components/SelectionLocalTranslator/hooks/useSelectionTranslation.ts
+++ b/src/presentation/components/SelectionLocalTranslator/hooks/useSelectionTranslation.ts
@@ -1,0 +1,74 @@
+import { useCallback, useState } from "react";
+import { GLOBAL_STRINGS } from "~@/config/utils/globalStrings";
+
+export type TranslationStatus = "idle" | "translating" | "done" | "error";
+
+export interface UseSelectionTranslationReturn {
+  status: TranslationStatus;
+  translatedText: string | null;
+  sourceLanguage: string | null;
+  errorMessage?: string;
+  translate: (text: string, targetLanguage: string) => Promise<void>;
+  reset: () => void;
+}
+
+interface SelectionMessageResponse {
+  translatedText: string;
+  sourceLanguage: string;
+}
+
+export const useSelectionTranslation = (): UseSelectionTranslationReturn => {
+  const [status, setStatus] = useState<TranslationStatus>("idle");
+  const [translatedText, setTranslatedText] = useState<string | null>(null);
+  const [sourceLanguage, setSourceLanguage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | undefined>(
+    undefined,
+  );
+
+  const translate = useCallback(
+    async (text: string, targetLanguage: string): Promise<void> => {
+      setStatus("translating");
+      setTranslatedText(null);
+      setSourceLanguage(null);
+      setErrorMessage(undefined);
+
+      return new Promise((resolve) => {
+        browser.runtime.sendMessage(
+          {
+            type: GLOBAL_STRINGS.BG_MESSAGE_TYPE.SELECTION_MESSAGE,
+            data: text,
+            target: targetLanguage,
+          },
+          (response: SelectionMessageResponse | undefined) => {
+            if (!response) {
+              setStatus("error");
+              setErrorMessage("Translation unavailable");
+              return resolve();
+            }
+            setTranslatedText(response.translatedText);
+            setSourceLanguage(response.sourceLanguage);
+            setStatus("done");
+            resolve();
+          },
+        );
+      });
+    },
+    [],
+  );
+
+  const reset = useCallback(() => {
+    setStatus("idle");
+    setTranslatedText(null);
+    setSourceLanguage(null);
+    setErrorMessage(undefined);
+  }, []);
+
+  return {
+    status,
+    translatedText,
+    sourceLanguage,
+    errorMessage,
+    translate,
+    reset,
+  };
+};

--- a/src/presentation/components/SelectionLocalTranslator/hooks/useTextSelection.ts
+++ b/src/presentation/components/SelectionLocalTranslator/hooks/useTextSelection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 interface TextSelection {
   text: string;
@@ -12,13 +12,29 @@ export interface UseTextSelectionReturn {
 
 export const useTextSelection = (): UseTextSelectionReturn => {
   const [selection, setSelection] = useState<TextSelection | null>(null);
+  const interactingWithTooltip = useRef(false);
 
   const clearSelection = useCallback(() => {
     setSelection(null);
   }, []);
 
   useEffect(() => {
+    const handleMouseDown = (e: MouseEvent) => {
+      const targetTagName = (e.target as Element).tagName;
+      if (targetTagName?.toUpperCase() === "SELECTION-LOCAL-TRANSLATOR") {
+        interactingWithTooltip.current = true;
+      }
+    };
+
+    const handleMouseUp = () => {
+      interactingWithTooltip.current = false;
+    };
+
     const handleSelectionChange = () => {
+      if (interactingWithTooltip.current) {
+        return;
+      }
+
       const sel = document.getSelection();
       if (!sel || sel.rangeCount === 0) {
         setSelection(null);
@@ -40,10 +56,14 @@ export const useTextSelection = (): UseTextSelectionReturn => {
       setSelection(null);
     };
 
+    document.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("mouseup", handleMouseUp);
     document.addEventListener("selectionchange", handleSelectionChange);
     document.addEventListener("scroll", handleScroll, true);
 
     return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("mouseup", handleMouseUp);
       document.removeEventListener("selectionchange", handleSelectionChange);
       document.removeEventListener("scroll", handleScroll, true);
     };

--- a/src/presentation/components/SelectionLocalTranslator/hooks/useTextSelection.ts
+++ b/src/presentation/components/SelectionLocalTranslator/hooks/useTextSelection.ts
@@ -52,20 +52,14 @@ export const useTextSelection = (): UseTextSelectionReturn => {
       setSelection({ text, rect });
     };
 
-    const handleScroll = () => {
-      setSelection(null);
-    };
-
     document.addEventListener("mousedown", handleMouseDown);
     document.addEventListener("mouseup", handleMouseUp);
     document.addEventListener("selectionchange", handleSelectionChange);
-    document.addEventListener("scroll", handleScroll, true);
 
     return () => {
       document.removeEventListener("mousedown", handleMouseDown);
       document.removeEventListener("mouseup", handleMouseUp);
       document.removeEventListener("selectionchange", handleSelectionChange);
-      document.removeEventListener("scroll", handleScroll, true);
     };
   }, []);
 

--- a/src/presentation/components/SelectionLocalTranslator/hooks/useTextSelection.ts
+++ b/src/presentation/components/SelectionLocalTranslator/hooks/useTextSelection.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from "react";
+
+interface TextSelection {
+  text: string;
+  rect: DOMRect;
+}
+
+export interface UseTextSelectionReturn {
+  selection: TextSelection | null;
+  clearSelection: () => void;
+}
+
+export const useTextSelection = (): UseTextSelectionReturn => {
+  const [selection, setSelection] = useState<TextSelection | null>(null);
+
+  const clearSelection = useCallback(() => {
+    setSelection(null);
+  }, []);
+
+  useEffect(() => {
+    const handleSelectionChange = () => {
+      const sel = document.getSelection();
+      if (!sel || sel.rangeCount === 0) {
+        setSelection(null);
+        return;
+      }
+
+      const text = sel.toString();
+      if (text.trim().length < 3) {
+        setSelection(null);
+        return;
+      }
+
+      const range = sel.getRangeAt(0);
+      const rect = range.getBoundingClientRect();
+      setSelection({ text, rect });
+    };
+
+    const handleScroll = () => {
+      setSelection(null);
+    };
+
+    document.addEventListener("selectionchange", handleSelectionChange);
+    document.addEventListener("scroll", handleScroll, true);
+
+    return () => {
+      document.removeEventListener("selectionchange", handleSelectionChange);
+      document.removeEventListener("scroll", handleScroll, true);
+    };
+  }, []);
+
+  return { selection, clearSelection };
+};

--- a/src/presentation/entrypoints/background/__test__/controller.test.ts
+++ b/src/presentation/entrypoints/background/__test__/controller.test.ts
@@ -87,6 +87,7 @@ describe("backgroundController", () => {
       expect(typeof backgroundController.handleChatMessage).toBe("function");
       expect(typeof backgroundController.handleInputMessage).toBe("function");
       expect(typeof backgroundController.handleCheckExtUpload).toBe("function");
+      expect(typeof backgroundController.handleSelectionMessage).toBe("function");
     });
 
     it("should be a valid controller object", () => {
@@ -204,6 +205,93 @@ describe("backgroundController", () => {
         sourceLanguage: "es",
         targetLanguage: "fr",
       });
+    });
+  });
+
+  describe("handleSelectionMessage", () => {
+    it("should return undefined when translator is not available", async () => {
+      vi.mocked(localTranslator.isAvailable).mockReturnValue(false);
+      vi.mocked(localLanguageDetector.isAvailable).mockReturnValue(true);
+
+      const result = await backgroundController.handleSelectionMessage(
+        "Hello world",
+        "es",
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined when language detector is not available", async () => {
+      vi.mocked(localTranslator.isAvailable).mockReturnValue(true);
+      vi.mocked(localLanguageDetector.isAvailable).mockReturnValue(false);
+
+      const result = await backgroundController.handleSelectionMessage(
+        "Hello world",
+        "es",
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should translate text and return translatedText with sourceLanguage", async () => {
+      vi.mocked(localTranslator.isAvailable).mockReturnValue(true);
+      vi.mocked(localLanguageDetector.isAvailable).mockReturnValue(true);
+      vi.mocked(localLanguageDetector.detectLanguage).mockResolvedValue("en");
+
+      const result = await backgroundController.handleSelectionMessage(
+        "Hello world",
+        "es",
+      );
+
+      expect(result).toEqual({
+        translatedText: "translated: Hello world",
+        sourceLanguage: "en",
+      });
+      expect(localTranslator.create).toHaveBeenCalledWith({
+        sourceLanguage: "en",
+        targetLanguage: "es",
+      });
+    });
+
+    it("should not block when source language equals target language (AC-05)", async () => {
+      vi.mocked(localTranslator.isAvailable).mockReturnValue(true);
+      vi.mocked(localLanguageDetector.isAvailable).mockReturnValue(true);
+      vi.mocked(localLanguageDetector.detectLanguage).mockResolvedValue("es");
+
+      const result = await backgroundController.handleSelectionMessage(
+        "Hola mundo",
+        "es",
+      );
+
+      expect(result).toEqual({
+        translatedText: "translated: Hola mundo",
+        sourceLanguage: "es",
+      });
+      expect(localTranslator.create).toHaveBeenCalledWith({
+        sourceLanguage: "es",
+        targetLanguage: "es",
+      });
+    });
+
+    it("should return undefined and log error on exception", async () => {
+      vi.mocked(localTranslator.isAvailable).mockReturnValue(true);
+      vi.mocked(localLanguageDetector.isAvailable).mockReturnValue(true);
+      vi.mocked(localLanguageDetector.detectLanguage).mockRejectedValue(
+        new Error("Detection failed"),
+      );
+
+      devConsole.error = vi.fn();
+
+      const result = await backgroundController.handleSelectionMessage(
+        "Hello world",
+        "es",
+      );
+
+      expect(result).toBeUndefined();
+      expect(devConsole.error).toHaveBeenCalledWith(
+        "Error translating selection:",
+        expect.any(Error),
+      );
     });
   });
 

--- a/src/presentation/entrypoints/background/controller.ts
+++ b/src/presentation/entrypoints/background/controller.ts
@@ -59,6 +59,8 @@ export const backgroundController = {
         return undefined;
       }
       const sourceLanguage = await localLanguageDetector.detectLanguage(text);
+      if (sourceLanguage === targetLanguage)
+        return { translatedText: text, sourceLanguage };
       const translator = await localTranslator.create({
         sourceLanguage: sourceLanguage ?? "en",
         targetLanguage,

--- a/src/presentation/entrypoints/background/controller.ts
+++ b/src/presentation/entrypoints/background/controller.ts
@@ -50,6 +50,26 @@ export const backgroundController = {
       return msg;
     }
   },
+  handleSelectionMessage: async (text: string, targetLanguage: string) => {
+    try {
+      if (
+        !localTranslator.isAvailable() ||
+        !localLanguageDetector.isAvailable()
+      ) {
+        return undefined;
+      }
+      const sourceLanguage = await localLanguageDetector.detectLanguage(text);
+      const translator = await localTranslator.create({
+        sourceLanguage: sourceLanguage ?? "en",
+        targetLanguage,
+      });
+      const translatedText = await translator.translate(text);
+      return { translatedText, sourceLanguage: sourceLanguage ?? "en" };
+    } catch (error) {
+      devConsole.error("Error translating selection:", error);
+      return undefined;
+    }
+  },
   handleCheckExtUpload: async () => {
     const isProd = import.meta.env.PROD;
     const currentVersion = browser.runtime.getManifest().version;

--- a/src/presentation/entrypoints/background/index.ts
+++ b/src/presentation/entrypoints/background/index.ts
@@ -28,6 +28,15 @@ export default defineBackground(() => {
           sendResponse(result);
         })();
         break;
+      case GLOBAL_STRINGS.BG_MESSAGE_TYPE.SELECTION_MESSAGE:
+        (async () => {
+          const result = await backgroundController.handleSelectionMessage(
+            message.data,
+            message.target,
+          );
+          sendResponse(result);
+        })();
+        break;
       default:
         break;
     }

--- a/src/presentation/entrypoints/selectionLocalTranslator.content/index.tsx
+++ b/src/presentation/entrypoints/selectionLocalTranslator.content/index.tsx
@@ -1,0 +1,27 @@
+import ReactDOM from "react-dom/client";
+import { SelectionLocalTranslator } from "~@/presentation/components/SelectionLocalTranslator/SelectionLocalTranslator";
+import "~@/presentation/assets/globals.css";
+
+export default defineContentScript({
+  matches: ["*://*/*"],
+  cssInjectionMode: "ui",
+
+  async main(ctx) {
+    const ui = await createShadowRootUi(ctx, {
+      name: "selection-local-translator",
+      position: "inline",
+      anchor: "body",
+      onMount: (container) => {
+        const app = document.createElement("div");
+        container.append(app);
+        const root = ReactDOM.createRoot(app);
+        root.render(<SelectionLocalTranslator />);
+        return root;
+      },
+      onRemove: (root) => {
+        root?.unmount();
+      },
+    });
+    ui.mount();
+  },
+});

--- a/src/presentation/hooks/useFeaturesStatus/useFeaturesStatus.test.ts
+++ b/src/presentation/hooks/useFeaturesStatus/useFeaturesStatus.test.ts
@@ -28,6 +28,11 @@ const mockSpeechToTranslateTabId = {
   setItem: vi.fn(),
   watchItem: vi.fn(),
 };
+const mockSelectionTranslator = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  watchItem: vi.fn(),
+};
 
 vi.mock("../useTranslatorStatus/useTranslatorStatus", () => ({
   useTranslatorStatus: () => mockTranslator,
@@ -49,6 +54,10 @@ vi.mock("../useSpeechToTranslateTabId/useSpeechToTranslateTabId", () => ({
   useSpeechToTranslateTabId: () => mockSpeechToTranslateTabId,
 }));
 
+vi.mock("../useSelectionTranslatorStatus/useSelectionTranslatorStatus", () => ({
+  useSelectionTranslatorStatus: () => mockSelectionTranslator,
+}));
+
 describe("useFeaturesStatus Hook", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -59,6 +68,7 @@ describe("useFeaturesStatus Hook", () => {
     mockQuickMenu.getItem.mockResolvedValue(false);
     mockSpeechToTranslateStatus.getItem.mockResolvedValue(false);
     mockSpeechToTranslateTabId.getItem.mockResolvedValue(null);
+    mockSelectionTranslator.getItem.mockResolvedValue(false);
   });
 
   it("should initialize with values from storage", async () => {
@@ -110,6 +120,27 @@ describe("useFeaturesStatus Hook", () => {
 
     expect(mockQuickMenu.setItem).toHaveBeenCalledWith(true);
     expect(result.current.quickMenu.isEnabled).toBe(true);
+  });
+
+  it("should initialize selectionTranslator from storage", async () => {
+    mockSelectionTranslator.getItem.mockResolvedValue(true);
+    const { result } = renderHook(() => useFeaturesStatus());
+    await waitFor(() => {
+      expect(result.current.isInitialized).toBe(true);
+      expect(result.current.selectionTranslator.isEnabled).toBe(true);
+    });
+  });
+
+  it("should toggle selectionTranslator status", async () => {
+    const { result } = renderHook(() => useFeaturesStatus());
+    await waitFor(() => expect(result.current.isInitialized).toBe(true));
+
+    await act(async () => {
+      await result.current.selectionTranslator.toggle(true);
+    });
+
+    expect(mockSelectionTranslator.setItem).toHaveBeenCalledWith(true);
+    expect(result.current.selectionTranslator.isEnabled).toBe(true);
   });
 
   it("should update state when watched value changes", async () => {

--- a/src/presentation/hooks/useFeaturesStatus/useFeaturesStatus.ts
+++ b/src/presentation/hooks/useFeaturesStatus/useFeaturesStatus.ts
@@ -4,6 +4,7 @@ import { useQuickMenuIsActive } from "../useQuickMenuIsActive/useQuickMenuIsActi
 import { useTranslatorStatus } from "../useTranslatorStatus/useTranslatorStatus";
 import { useSpeechToTranslateStatus } from "../useSpeechToTranslateStatus/useSpeechToTranslateStatus";
 import { useSpeechToTranslateTabId } from "../useSpeechToTranslateTabId/useSpeechToTranslateTabId";
+import { useSelectionTranslatorStatus } from "../useSelectionTranslatorStatus/useSelectionTranslatorStatus";
 
 interface FeatureStatus {
   isEnabled: boolean;
@@ -15,6 +16,7 @@ interface UseFeaturesStatus {
   quickMessages: FeatureStatus;
   quickMenu: FeatureStatus;
   speechToTranslate: FeatureStatus;
+  selectionTranslator: FeatureStatus;
   isInitialized: boolean;
 }
 
@@ -29,29 +31,34 @@ export const useFeaturesStatus = (): UseFeaturesStatus => {
   const quickMenuIsActive = useQuickMenuIsActive();
   const speechToTranslateStatusStorage = useSpeechToTranslateStatus();
   const speechToTranslateTabIdStorage = useSpeechToTranslateTabId();
+  const selectionTranslatorStatusStorage = useSelectionTranslatorStatus();
 
   const [isTranslatorEnabled, setIsTranslatorEnabled] = useState(false);
   const [isQuickMessagesEnabled, setIsQuickMessagesEnabled] = useState(false);
   const [isQuickMenuEnabled, setIsQuickMenuEnabled] = useState(false);
   const [isSpeechToTranslateEnabled, setIsSpeechToTranslateEnabled] =
     useState(false);
+  const [isSelectionTranslatorEnabled, setIsSelectionTranslatorEnabled] =
+    useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
 
   const initFeaturesState = useCallback(async () => {
     if (isInitialized) return;
 
-    const [translator, quickMessages, quickMenu, speechToTranslate] =
+    const [translator, quickMessages, quickMenu, speechToTranslate, selectionTranslator] =
       await Promise.all([
         translatorStatus.getItem(),
         quickMessagesStatus.getItem(),
         quickMenuIsActive.getItem(),
         speechToTranslateStatusStorage.getItem(),
+        selectionTranslatorStatusStorage.getItem(),
       ]);
 
     setIsTranslatorEnabled(translator);
     setIsQuickMessagesEnabled(quickMessages);
     setIsQuickMenuEnabled(quickMenu);
     setIsSpeechToTranslateEnabled(speechToTranslate);
+    setIsSelectionTranslatorEnabled(selectionTranslator);
     setIsInitialized(true);
   }, [
     isInitialized,
@@ -59,6 +66,7 @@ export const useFeaturesStatus = (): UseFeaturesStatus => {
     quickMessagesStatus,
     quickMenuIsActive,
     speechToTranslateStatusStorage,
+    selectionTranslatorStatusStorage,
   ]);
 
   useEffect(() => {
@@ -70,12 +78,16 @@ export const useFeaturesStatus = (): UseFeaturesStatus => {
     speechToTranslateStatusStorage.watchItem((value) =>
       setIsSpeechToTranslateEnabled(value),
     );
+    selectionTranslatorStatusStorage.watchItem((value) =>
+      setIsSelectionTranslatorEnabled(value),
+    );
   }, [
     initFeaturesState,
     translatorStatus,
     quickMessagesStatus,
     quickMenuIsActive,
     speechToTranslateStatusStorage,
+    selectionTranslatorStatusStorage,
   ]);
 
   const toggleTranslator = useCallback(
@@ -100,6 +112,14 @@ export const useFeaturesStatus = (): UseFeaturesStatus => {
       setIsQuickMenuEnabled(checked);
     },
     [quickMenuIsActive],
+  );
+
+  const toggleSelectionTranslator = useCallback(
+    async (checked: boolean) => {
+      await selectionTranslatorStatusStorage.setItem(checked);
+      setIsSelectionTranslatorEnabled(checked);
+    },
+    [selectionTranslatorStatusStorage],
   );
 
   const toggleSpeechToTranslate = useCallback(
@@ -147,6 +167,10 @@ export const useFeaturesStatus = (): UseFeaturesStatus => {
     speechToTranslate: {
       isEnabled: isSpeechToTranslateEnabled,
       toggle: toggleSpeechToTranslate,
+    },
+    selectionTranslator: {
+      isEnabled: isSelectionTranslatorEnabled,
+      toggle: toggleSelectionTranslator,
     },
     isInitialized,
   };

--- a/src/presentation/hooks/useSelectionTranslatorStatus/useSelectionTranslatorStatus.test.ts
+++ b/src/presentation/hooks/useSelectionTranslatorStatus/useSelectionTranslatorStatus.test.ts
@@ -1,0 +1,53 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { useSelectionTranslatorStatus } from "./useSelectionTranslatorStatus";
+
+const browser = (globalThis as any).browser;
+
+vi.mock("~@/config/utils/globalStrings", () => ({
+  GLOBAL_STRINGS: {
+    STORAGE_KEYS: {
+      SELECTION_TRANSLATOR_IS_ACTIVE: "selection_translator_is_active",
+    },
+  },
+}));
+
+describe("useSelectionTranslatorStatus Hook", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await browser.storage.local.clear();
+  });
+
+  it("should get item value (default true)", async () => {
+    const { result } = renderHook(() => useSelectionTranslatorStatus());
+    expect(await result.current.getItem()).toBe(true);
+
+    await browser.storage.local.set({ selection_translator_is_active: false });
+    expect(await result.current.getItem()).toBe(false);
+  });
+
+  it("should set item value", async () => {
+    const { result } = renderHook(() => useSelectionTranslatorStatus());
+
+    await result.current.setItem(false);
+
+    const value = await result.current.getItem();
+    expect(value).toBe(false);
+
+    const storageData = await browser.storage.local.get(null);
+    expect(storageData["selection_translator_is_active"]).toBe(false);
+  });
+
+  it("should watch item changes", async () => {
+    const { result } = renderHook(() => useSelectionTranslatorStatus());
+    const callback = vi.fn();
+
+    await result.current.watchItem(callback);
+
+    await browser.storage.local.set({ selection_translator_is_active: true });
+    expect(callback).toHaveBeenCalledWith(true);
+
+    await browser.storage.local.set({ selection_translator_is_active: false });
+    expect(callback).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/presentation/hooks/useSelectionTranslatorStatus/useSelectionTranslatorStatus.ts
+++ b/src/presentation/hooks/useSelectionTranslatorStatus/useSelectionTranslatorStatus.ts
@@ -1,0 +1,8 @@
+import { GLOBAL_STRINGS } from "~@/config/utils/globalStrings";
+
+import { createStorageHook } from "../useStorageItem/useStorageItem";
+
+export const useSelectionTranslatorStatus = createStorageHook<boolean>(
+  GLOBAL_STRINGS.STORAGE_KEYS.SELECTION_TRANSLATOR_IS_ACTIVE,
+  true,
+);

--- a/src/presentation/hooks/useSelectionTranslatorTargetLanguage/useSelectionTranslatorTargetLanguage.ts
+++ b/src/presentation/hooks/useSelectionTranslatorTargetLanguage/useSelectionTranslatorTargetLanguage.ts
@@ -1,0 +1,7 @@
+import { GLOBAL_STRINGS } from "~@/config/utils/globalStrings";
+import { createStorageHook } from "../useStorageItem/useStorageItem";
+
+export const useSelectionTranslatorTargetLanguage = createStorageHook<string>(
+  GLOBAL_STRINGS.STORAGE_KEYS.SELECTION_TRANSLATOR_TARGET_LANGUAGE,
+  "en",
+);


### PR DESCRIPTION
## Release 1.5.0

### Overview
Introduces a full selected-text translator feature: users can select text on supported sites and get an inline translation via a new SelectionBubble trigger and SelectionTooltip result UI. Backing infrastructure includes new hooks for text selection and translation requests, a background message handler, and a storage hook factory that eliminates boilerplate across 10 hooks.

### Changes

### Added

- Add selectionTranslator to useFeaturesStatus hook (ac10465)
- Add SelectionTooltip component for showing translation results (c3e972a)
- Add SelectionBubble component for translation trigger UI (391ae31)
- Add useSelectionTranslation hook for handling translation requests (97c88b6)
- Add useTextSelection hook for handling text selection events (48bc3df)
- Add SELECTION_MESSAGE handler and useSelectionTranslatorStatus hook (c2a11f1)
- Add handleSelectionMessage to background controller (5db625b)

### Changed

- Extract storage hook factory to eliminate duplicated WXT storage boilerplate across 10 hooks (50adf78)
- Separate localStorage keys for language selector between tooltip and popup (81d831b)
- Use native select component and prevent tooltip close on self-click (7b9aeae)
- Extract LanguageSelectorControlled as presentational component (ccd1eb6)

### Fixed

- Return text directly when source and target languages match (f42ce99)
- Correct SelectionBubble positioning with scroll offset (95a25ec)

### Checklist
- [ ] CHANGELOG reviewed
- [ ] Tests passing
- [ ] No breaking changes undocumented